### PR TITLE
Prevent old versions from being indexed

### DIFF
--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,1 +1,4 @@
-    {{!-- Add additional meta tags here --}}
+{{!-- Prevent old versions from being indexed by search engines --}}
+{{#if (ne page.version page.component.latest.version)}}
+<meta name="robots" content="noindex">
+{{/if}}


### PR DESCRIPTION
See https://developers.google.com/search/docs/crawling-indexing/block-indexing

For a discussion on the issue, see https://antora.zulipchat.com/#narrow/stream/282400-users/topic/.E2.9C.94.20Edit.20sitemap.20in.20an.20extension