### PR TITLE
Apply noindex only to prerelease versions

### DIFF
--- a/src/helpers/is-beta.js
+++ b/src/helpers/is-beta.js
@@ -3,7 +3,7 @@ module.exports = (currentPage) => {
   for (let i = 0; i < currentPage.component.versions.length; i++) {
     const version = currentPage.component.versions[i].version
     if (currentVersion === version) {
-      if (version.prerelease === 'true') {
+      if (currentPage.component.versions[i].prerelease === true) {
         return true
       } else {
         return false

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,4 +1,4 @@
 {{!-- Prevent old versions from being indexed by search engines --}}
-{{#if (ne page.version page.component.latest.version)}}
+{{#if (is-beta page)}}
 <meta name="robots" content="noindex">
 {{/if}}

--- a/src/partials/head-title.hbs
+++ b/src/partials/head-title.hbs
@@ -1,1 +1,1 @@
-    <title>{{{detag (or page.title defaultPageTitle)}}}{{#with site.title}} :: {{this}}{{/with}}</title>
+    <title>{{{detag (or page.title defaultPageTitle)}}}{{#with site.title}} | {{this}}{{/with}}</title>


### PR DESCRIPTION
We don't want to stop search engines from finding old versions because they help our ranking. Instead, we want to use canonical URLs to tell search engines to prefer the latest version.

However, beta URLs are often ephemeral, so we do want to give those pages `no-index` so that they are ignored by search engines.

This PR removes `no-index` meta tags from old version pages and adds them to beta (prerelease) pages.