### PR TITLE
Fix bugs in index pages and pages with no ToC

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -11,7 +11,7 @@
 @media screen and (min-width: 1024px) {
   main {
     margin: 0 auto;
-    max-width: calc(100% - var(--nav-width));
+    width: calc(100% - var(--nav-width));
     padding-top: 20px;
     min-width: 0; /* min-width: 0 required for flexbox to constrain overflowing elements */
   }

--- a/src/partials/article-index.hbs
+++ b/src/partials/article-index.hbs
@@ -9,8 +9,8 @@
   {{#if (and (eq this.url @root.page.url) (ne this.items.length 0))}}
     {{#each this.items}}
       {{#with (get-page-info this.url)}}
-        <li class="index"><a href="{{this.url}}">{{this.title}}</a>
-        <p class="index">{{this.description}}</p>
+        <li class="index"><a href="{{this.url}}">{{{this.title}}}</a>
+        <p class="index">{{{this.description}}}</p>
         </li>
       {{/with}}
     {{/each}}


### PR DESCRIPTION
- Replaced double curly braces with tripe curly braces in the index page template so that special characters don't get URL encoded.
- Fixed the width of content pages that don't include a table of contents.
