### PR TITLE
Make the ToC feedback thumbs disappear

### DIFF
--- a/src/partials/feedback-form-script.hbs
+++ b/src/partials/feedback-form-script.hbs
@@ -40,7 +40,7 @@ const handleSubmit = function (e) {
 
   formData.set('email', (form.querySelector('input[name="email"]').value))
 
-  formData.set('date', new Date().toISOString())
+  formData.set('date', new Date())
   formData.set('navigator', JSON.stringify({
     appName: window.navigator.appName,
     appVersion: window.navigator.appVersion,

--- a/src/partials/thumbs.hbs
+++ b/src/partials/thumbs.hbs
@@ -14,7 +14,7 @@ document.addEventListener('scroll', function(e){
   let documentHeight = document.body.scrollHeight;
   let currentScroll = window.scrollY + window.innerHeight;
   // Wait until the user is [modifier]px from the bottom.
-  let modifier = 200;
+  let modifier = 700;
   const feedback = document.getElementById('thumbs-toc');
   if (!feedback) return
   if(currentScroll + modifier > documentHeight) {


### PR DESCRIPTION
- Made the ToC feedback thumbs disappear before the user scrolls to the feedback footer.
- Improved the date format for the feedback form.