### PR TITLE
Add click-to-zoom feature for Mermaid diagrams

### DIFF
--- a/preview-src/mermaid-test.adoc
+++ b/preview-src/mermaid-test.adoc
@@ -1,0 +1,137 @@
+= Mermaid Diagram Test
+:page-layout: default
+
+Test page for Mermaid diagram sizing, zoom, and clickable links.
+
+TIP: Click any diagram to zoom. Click nodes with links to navigate to sections.
+
+++++
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({startOnLoad: true, securityLevel: 'loose'});</script>
+++++
+
+== Clickable Navigation
+
+This flowchart has clickable nodes that link to sections below:
+
+++++
+<div class="mermaid">
+flowchart LR
+    A[Start Here] --> B[View Flowchart]
+    B --> C[See Sequence]
+    C --> D[Check Classes]
+    click B "#larger-flowchart" "Jump to Larger Flowchart"
+    click C "#sequence-diagram" "Jump to Sequence Diagram"
+    click D "#class-diagram" "Jump to Class Diagram"
+</div>
+++++
+
+== Simple Flowchart
+
+++++
+<div class="mermaid">
+flowchart LR
+    A[Start] --> B[Process]
+    B --> C[End]
+</div>
+++++
+
+[[larger-flowchart]]
+== Larger Flowchart
+
+++++
+<div class="mermaid">
+flowchart TD
+    A[Client] --> B[Load Balancer]
+    B --> C[Server 1]
+    B --> D[Server 2]
+    B --> E[Server 3]
+    C --> F[(Database)]
+    D --> F
+    E --> F
+    F --> G[Cache]
+    G --> H[Response]
+</div>
+++++
+
+[[sequence-diagram]]
+== Sequence Diagram
+
+++++
+<div class="mermaid">
+sequenceDiagram
+    participant Client
+    participant API
+    participant Database
+    Client->>API: Request
+    API->>Database: Query
+    Database-->>API: Results
+    API-->>Client: Response
+</div>
+++++
+
+== Wide Sequence Diagram
+
+++++
+<div class="mermaid">
+sequenceDiagram
+    participant Browser
+    participant CDN
+    participant LoadBalancer
+    participant AppServer
+    participant Cache
+    participant Database
+    participant MessageQueue
+
+    Browser->>CDN: Request static assets
+    CDN-->>Browser: Return cached assets
+    Browser->>LoadBalancer: API Request
+    LoadBalancer->>AppServer: Forward request
+    AppServer->>Cache: Check cache
+    Cache-->>AppServer: Cache miss
+    AppServer->>Database: Query data
+    Database-->>AppServer: Return data
+    AppServer->>Cache: Store in cache
+    AppServer->>MessageQueue: Publish event
+    AppServer-->>LoadBalancer: Response
+    LoadBalancer-->>Browser: Return response
+</div>
+++++
+
+[[class-diagram]]
+== Class Diagram
+
+++++
+<div class="mermaid">
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        +makeSound()
+    }
+    class Dog {
+        +String breed
+        +bark()
+    }
+    class Cat {
+        +String color
+        +meow()
+    }
+    Animal <|-- Dog
+    Animal <|-- Cat
+</div>
+++++
+
+== State Diagram
+
+++++
+<div class="mermaid">
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : start
+    Processing --> Success : complete
+    Processing --> Error : fail
+    Success --> [*]
+    Error --> Idle : retry
+</div>
+++++

--- a/src/css/mermaid-zoom.css
+++ b/src/css/mermaid-zoom.css
@@ -1,0 +1,133 @@
+.mermaid-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  background: #1a1a1a;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2147483647;
+  padding: 2rem;
+  box-sizing: border-box;
+  isolation: isolate;
+}
+
+.mermaid-modal-overlay.active {
+  display: flex;
+}
+
+.mermaid-modal-container {
+  display: block;
+  max-width: calc(100vw - 4rem);
+  max-height: calc(100vh - 6rem);
+  overflow: auto;
+  text-align: center;
+  background: var(--body-background, #fff);
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
+  cursor: grab;
+}
+
+.mermaid-modal-container:active {
+  cursor: grabbing;
+}
+
+/* Always show scrollbars for discoverability */
+.mermaid-modal-container::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.mermaid-modal-container::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+}
+
+.mermaid-modal-container::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+}
+
+.mermaid-modal-container::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.mermaid-modal-container svg {
+  display: block;
+  margin: 0 auto;
+}
+
+/* Scroll hint that appears briefly */
+.mermaid-modal-hint {
+  position: fixed;
+  bottom: 3rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255, 255, 255, 0.95);
+  color: #333;
+  padding: 0.75rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.5s ease;
+  z-index: 10;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.mermaid-modal-hint.hidden {
+  opacity: 0;
+}
+
+.mermaid-modal-close {
+  position: fixed;
+  top: 1rem;
+  right: 1.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: none;
+  font-size: 1.5rem;
+  color: #333;
+  cursor: pointer;
+  z-index: 10;
+  line-height: 1;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.mermaid-modal-close:hover {
+  background: rgba(255, 255, 255, 1);
+}
+
+.mermaid-modal-close:focus {
+  outline: 2px solid #333;
+  outline-offset: 2px;
+}
+
+/* Zoom-in cursor hint on mermaid diagrams */
+.mermaid {
+  cursor: zoom-in;
+}
+
+.mermaid:focus-visible {
+  outline: 2px solid var(--body-font-color, #333);
+  outline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mermaid-modal-close,
+  .mermaid-modal-hint {
+    transition: none;
+  }
+}

--- a/src/css/mermaid.css
+++ b/src/css/mermaid.css
@@ -1,3 +1,27 @@
+.mermaid {
+  display: block;
+  width: 100%;
+  text-align: center;
+}
+
 .mermaid > svg {
   background-color: var(--body-background) !important;
+  max-width: 100%;
+  height: auto;
+  min-width: 200px;
+  /* Override any inherited aspect-ratio (e.g., from .doc .image > svg) */
+  aspect-ratio: auto !important;
+}
+
+/* Styling for clickable links in Mermaid diagrams */
+.mermaid a {
+  text-decoration: none;
+}
+
+.mermaid .node:hover {
+  filter: brightness(1.05);
+}
+
+.mermaid .clickable {
+  cursor: pointer;
 }

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -10,6 +10,7 @@
 @import "modal.css";
 @import "home.css";
 @import "mermaid.css";
+@import "mermaid-zoom.css";
 @import "component-home.css";
 @import "component-home-v2.css";
 @import "nav.css";

--- a/src/js/20-mermaid-zoom.js
+++ b/src/js/20-mermaid-zoom.js
@@ -1,0 +1,197 @@
+;(function () {
+  'use strict'
+
+  // Only initialize if there are Mermaid diagrams on the page
+  const mermaidBlocks = document.querySelectorAll('.mermaid')
+  if (!mermaidBlocks.length) return
+
+  // Create modal overlay (reused for all diagrams)
+  const modalOverlay = document.createElement('div')
+  modalOverlay.className = 'mermaid-modal-overlay'
+  modalOverlay.setAttribute('role', 'dialog')
+  modalOverlay.setAttribute('aria-modal', 'true')
+  modalOverlay.setAttribute('aria-label', 'Mermaid diagram zoom view')
+  modalOverlay.innerHTML = `
+    <button class="mermaid-modal-close" aria-label="Close diagram">&times;</button>
+    <div class="mermaid-modal-container"></div>
+    <div class="mermaid-modal-hint">Drag or scroll to pan around the diagram</div>
+  `
+  document.body.appendChild(modalOverlay)
+
+  const modalContainer = modalOverlay.querySelector('.mermaid-modal-container')
+  const modalClose = modalOverlay.querySelector('.mermaid-modal-close')
+  const modalHint = modalOverlay.querySelector('.mermaid-modal-hint')
+
+  // Drag-to-scroll variables
+  var isDragging = false
+  var startX, startY, scrollLeft, scrollTop
+
+  // Focus management for accessibility
+  var lastFocusedElement = null
+
+  function openModal (svg) {
+    // Save the currently focused element to restore later
+    lastFocusedElement = document.activeElement
+    const clone = svg.cloneNode(true)
+
+    // Get the original SVG dimensions
+    var rect = svg.getBoundingClientRect()
+    var origWidth = rect.width || 400
+    var origHeight = rect.height || 300
+    var aspectRatio = origWidth / origHeight
+
+    // Calculate target dimensions to fill viewport
+    var maxWidth = window.innerWidth * 0.92
+    var maxHeight = window.innerHeight * 0.85
+
+    var targetWidth, targetHeight
+
+    // For wide diagrams (aspect ratio > 2), prioritize filling width
+    // and allow scrolling if needed
+    if (aspectRatio > 2) {
+      targetWidth = maxWidth
+      targetHeight = targetWidth / aspectRatio
+      // If still too short to read, make it taller
+      if (targetHeight < maxHeight * 0.5) {
+        targetHeight = maxHeight * 0.7
+        targetWidth = targetHeight * aspectRatio
+      }
+    } else {
+      // For normal diagrams, fit within viewport
+      if (aspectRatio > maxWidth / maxHeight) {
+        targetWidth = maxWidth
+        targetHeight = targetWidth / aspectRatio
+      } else {
+        targetHeight = maxHeight
+        targetWidth = targetHeight * aspectRatio
+      }
+    }
+
+    // Ensure minimum size for readability (at least 2x original or fill viewport)
+    var minScale = 2
+    if (targetWidth < origWidth * minScale && targetHeight < origHeight * minScale) {
+      targetWidth = Math.min(origWidth * minScale, maxWidth * 1.5)
+      targetHeight = targetWidth / aspectRatio
+    }
+
+    // Apply dimensions directly to SVG (not transform)
+    clone.style.width = targetWidth + 'px'
+    clone.style.height = targetHeight + 'px'
+    clone.style.minWidth = targetWidth + 'px'
+    clone.style.minHeight = targetHeight + 'px'
+    clone.style.maxWidth = 'none'
+    clone.style.maxHeight = 'none'
+    clone.removeAttribute('width')
+    clone.removeAttribute('height')
+
+    modalContainer.innerHTML = ''
+    modalContainer.appendChild(clone)
+    modalOverlay.classList.add('active')
+    document.body.style.overflow = 'hidden'
+
+    // Check if scrolling is needed and show hint
+    setTimeout(function () {
+      var needsScroll = modalContainer.scrollWidth > modalContainer.clientWidth ||
+                        modalContainer.scrollHeight > modalContainer.clientHeight
+      if (needsScroll) {
+        modalHint.classList.remove('hidden')
+        // Auto-hide hint after 3 seconds
+        setTimeout(function () {
+          modalHint.classList.add('hidden')
+        }, 3000)
+      } else {
+        modalHint.classList.add('hidden')
+      }
+    }, 100)
+
+    modalClose.focus()
+  }
+
+  function closeModal () {
+    modalOverlay.classList.remove('active')
+    document.body.style.overflow = ''
+    modalHint.classList.add('hidden')
+
+    // Restore focus to the element that opened the modal
+    if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+      lastFocusedElement.focus()
+      lastFocusedElement = null
+    }
+  }
+
+  // Drag-to-scroll functionality
+  modalContainer.addEventListener('mousedown', function (e) {
+    // Don't start drag if clicking close button
+    if (e.target === modalClose) return
+    isDragging = true
+    modalContainer.style.cursor = 'grabbing'
+    startX = e.pageX - modalContainer.offsetLeft
+    startY = e.pageY - modalContainer.offsetTop
+    scrollLeft = modalContainer.scrollLeft
+    scrollTop = modalContainer.scrollTop
+    e.preventDefault()
+  })
+
+  modalContainer.addEventListener('mouseleave', function () {
+    isDragging = false
+    modalContainer.style.cursor = 'grab'
+  })
+
+  modalContainer.addEventListener('mouseup', function () {
+    isDragging = false
+    modalContainer.style.cursor = 'grab'
+  })
+
+  modalContainer.addEventListener('mousemove', function (e) {
+    if (!isDragging) return
+    e.preventDefault()
+    var x = e.pageX - modalContainer.offsetLeft
+    var y = e.pageY - modalContainer.offsetTop
+    var walkX = (x - startX) * 1.5
+    var walkY = (y - startY) * 1.5
+    modalContainer.scrollLeft = scrollLeft - walkX
+    modalContainer.scrollTop = scrollTop - walkY
+  })
+
+  // Attach click handlers to all Mermaid diagrams
+  mermaidBlocks.forEach(function (block) {
+    block.style.cursor = 'zoom-in'
+    block.setAttribute('role', 'button')
+    block.setAttribute('tabindex', '0')
+    block.setAttribute('aria-label', 'Click to zoom diagram')
+
+    block.addEventListener('click', function (e) {
+      // Don't zoom if clicking on a link inside the diagram
+      if (e.target.closest('a')) return
+
+      const svg = block.querySelector('svg')
+      if (svg) openModal(svg)
+    })
+
+    // Keyboard support
+    block.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        const svg = block.querySelector('svg')
+        if (svg) openModal(svg)
+      }
+    })
+  })
+
+  // Close button click
+  modalClose.addEventListener('click', closeModal)
+
+  // Click outside to close (but not when dragging)
+  modalOverlay.addEventListener('click', function (e) {
+    if (e.target === modalOverlay && !isDragging) {
+      closeModal()
+    }
+  })
+
+  // Escape key to close
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && modalOverlay.classList.contains('active')) {
+      closeModal()
+    }
+  })
+})()

--- a/src/partials/header-scripts.hbs
+++ b/src/partials/header-scripts.hbs
@@ -18,5 +18,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!--  https://github.com/snt/antora-mermaid-extension -->
 <!-- Only load Mermaid on pages that aren't home/labs to avoid request chain on landing pages -->
 {{#unless (or (eq page.attributes.role 'home') (eq page.layout 'labs-search'))}}
+<script>
+  // Configure Mermaid before it loads to enable clickable links in diagrams
+  // securityLevel: 'loose' allows click events and links to work
+  window.mermaidConfig = { securityLevel: 'loose', startOnLoad: true };
+</script>
 {{> mermaid-scripts}}
 {{/unless}}


### PR DESCRIPTION
## Summary
- Adds click-to-zoom functionality for Mermaid diagrams - clicking any diagram opens it in a fullscreen modal
- Diagrams are scaled up for better readability, with drag-to-scroll and mouse wheel support for large/wide diagrams
- Brief hint message appears: "Drag or scroll to pan around the diagram"
- Enables clickable links within Mermaid diagrams (nodes can link to page sections)
- Includes test page with various diagram types for verification

## Test plan
- [ ] Navigate to https://deploy-preview-374--docs-ui.netlify.app/mermaid-test.html
- [ ] Click on any diagram to verify zoom modal opens
- [ ] Verify wide sequence diagram is scrollable (drag or scroll to pan)
- [ ] Verify hint message appears briefly when opening a large diagram
- [ ] Press Escape or click X to close modal