### PR TITLE
Add cookie preferences link to footer site-wide

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -71,6 +71,7 @@
           </div>
           <div class="footer__legal-container">
             <a href="https://redpanda.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer" class="text-style-footer-legal">Privacy policy</a>
+            <a data-onetrust="true" href="#" class="text-style-footer-legal">Cookie preferences</a>
             <div class="text-style-footer-legal">© {{year}} Redpanda. All rights reserved.</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Adds footer with cookie preferences link to all documentation pages
- Aligns documentation site with other Redpanda web properties
- Enables users to manage cookie consent settings and CCPA opt-out

## Changes
- Added `data-onetrust="true"` attribute to cookie preferences link in footer
- Added footer partial to all page layouts (index, default, 404, lab)
- Cookie preferences link positioned between privacy policy and copyright

## Test plan
- [ ] Build UI bundle and verify no build errors
- [ ] Test footer appears on home page
- [ ] Test footer appears on article pages
- [ ] Test footer appears on 404 page
- [ ] Test footer appears on lab pages
- [ ] Verify cookie preferences link triggers OneTrust modal

Fixes DOC-2102

🤖 Generated with [Claude Code](https://claude.com/claude-code)