### PR TITLE
Remove ADP availability admonition for GA descope

### DIFF
--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -47,51 +47,6 @@
   {{> markdown-dropdown}}
 </div>
 {{/unless}}
-{{!-- Availability block for ADP pages showing platform support --}}
-{{#if page.attributes.adp}}
-{{#unless (eq page.attributes.role 'component-home-v2')}}
-{{#unless (eq page.attributes.role 'home')}}
-{{#unless (eq page.layout 'index')}}
-<div class="availability-block">
-  <strong>Available in:</strong>
-  {{#if (and page.attributes.byoc page.attributes.cloud-only)}}
-    Cloud, BYOC
-  {{else if page.attributes.byoc}}
-    BYOC
-  {{else if page.attributes.cloud-only}}
-    Cloud
-  {{else}}
-    Cloud, BYOC
-  {{/if}}
-  <span class="availability-info" tabindex="0" aria-label="Availability information">
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"></circle>
-      <line x1="12" y1="16" x2="12" y2="12"></line>
-      <line x1="12" y1="8" x2="12.01" y2="8"></line>
-    </svg>
-  </span>
-</div>
-<script>
-document.addEventListener("DOMContentLoaded", () => {
-  const availabilityInfo = document.querySelector(".availability-info");
-  if (availabilityInfo && typeof tippy !== 'undefined') {
-    tippy(availabilityInfo, {
-      content: "This indicates which Redpanda Cloud cluster types support this feature. Cloud refers to fully managed clusters. BYOC (Bring Your Own Cloud) refers to clusters running in your own cloud account.",
-      animation: "scale",
-      theme: "redpanda-term",
-      touch: "hold",
-      interactive: true,
-      allowHTML: true,
-      appendTo: () => document.body,
-      maxWidth: 300
-    });
-  }
-});
-</script>
-{{/unless}}
-{{/unless}}
-{{/unless}}
-{{/if}}
 {{#if (or page.attributes.beta page.attributes.limited-availability page.attributes.byoc page.attributes.cloud-only page.attributes.context-switcher)}}
   <script>
   document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary

Drops the `page.attributes.adp` availability block from `src/partials/article.hbs`. ADP Cloud is descoped from the 2026-06-15 GA, so BYOC is the only deployment shape and the "Available in: Cloud, BYOC" / "Available in: BYOC" admonition that the bundle injects on every ADP page no longer informs the reader.

The block was added in 37bacc1 ("Add availability block and enhance ADP page styling") and refined in 5b36bdd ("Address CodeRabbit review comments"). This PR removes it entirely now that the descope decision has landed.

Other badges keep working unchanged: `beta`, `limited-availability`, `context-switcher`, and the BYOC / Cloud nav-metadata labels for non-ADP pages (lines 32-43 are untouched, still gated on `{{#unless page.attributes.adp}}`).

## Companion PR

[redpanda-data/adp-docs#13](https://github.com/redpanda-data/adp-docs/pull/13) ships the same change locally as an Antora `supplemental_files` override so the deploy preview build is fixed immediately, ahead of a docs-ui release. Once this PR merges, a new release tag is cut from `feature/badge-byoc-only`, and the `adp-docs` / `docs-site` playbooks are bumped to the new release, the `supplemental-ui/` override in adp-docs becomes redundant and can be deleted (cleanup PR will follow).

## Test plan

- [x] `gulp lint` passes cleanly (CSS + JS).
- [ ] After release: `adp-docs` build with the new bundle no longer renders any `<div class="availability-block">` on ADP pages.
- [ ] After release: non-ADP pages still get the BYOC / Cloud nav badges where applicable.
- [ ] After release: beta and limited-availability badges still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
