### PR TITLE
Fix mobile nav toggle visibility on dark hero backgrounds

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -388,4 +388,11 @@ page:
       - content: Limited Availability Test
         url: /streaming/24.3/limited-availability-test.html
         urlType: internal
+    - content: Dev Tools
+      url: '#'
+      urlType: internal
+      items:
+      - content: Widget Test (Bump.sh)
+        url: /_/widget-test.html
+        urlType: internal
 

--- a/src/css/component-home-v3.css
+++ b/src/css/component-home-v3.css
@@ -3,6 +3,11 @@
    Matches "docs design (2)" with hero, tabs, and "Choose your path" cards
    ============================================================================= */
 
+/* Mobile nav toggle: invert to white on dark hero background */
+.component-home .nav-toggle {
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(248deg) brightness(105%) contrast(101%);
+}
+
 /* Hide all icons on landing pages */
 .ch3-path-icon,
 .ch3-deploy-icon,

--- a/src/css/data-platform.css
+++ b/src/css/data-platform.css
@@ -2,6 +2,11 @@
    This page serves as the umbrella landing for Self-managed, Cloud, and Connect docs.
    =================================================================================== */
 
+/* Mobile nav toggle: invert to white on dark hero background */
+.data-platform .nav-toggle {
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(248deg) brightness(105%) contrast(101%);
+}
+
 /* Hide all icons on landing page */
 .dp-product-bullet-icon,
 .dp-popular-icon {

--- a/src/css/home.css
+++ b/src/css/home.css
@@ -2,6 +2,11 @@ body.article.home {
   background-color: var(--home-background);
 }
 
+/* Mobile nav toggle: invert to white on dark hero background */
+body.article.home .nav-toggle {
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(248deg) brightness(105%) contrast(101%);
+}
+
 /* Layout: full-width content area for home page */
 /* Higher specificity selector to override main > .content (main.css:52-64) */
 main.article.home > .content {

--- a/src/css/labs-home.css
+++ b/src/css/labs-home.css
@@ -3,6 +3,11 @@
    Styling for the Labs landing page with hero, filters, and card grid
    ============================================================================= */
 
+/* Mobile nav toggle: invert to white on dark hero background */
+.labs-wrap .nav-toggle {
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(248deg) brightness(105%) contrast(101%);
+}
+
 /* Labs page wrapper */
 .labs-wrap {
   background: var(--body-background);


### PR DESCRIPTION
## Summary

Fix the mobile navigation toggle (hamburger menu) icon being nearly invisible on landing pages with dark hero backgrounds in Brave browser and other browsers.

## Problem

The nav toggle icon uses a dark color (`#222`) that doesn't contrast against the dark gradient backgrounds on:
- Data Platform landing page
- Labs home page  
- Component home pages (Self-managed, Cloud, Connect)
- Main home page

## Solution

Apply the same CSS `filter: invert()` used in dark mode to these specific landing pages, making the icon white and visible against dark backgrounds.

## Files Changed

| File | Change |
|------|--------|
| `src/css/data-platform.css` | Add nav-toggle invert filter |
| `src/css/labs-home.css` | Add nav-toggle invert filter |
| `src/css/component-home-v3.css` | Add nav-toggle invert filter |
| `src/css/home.css` | Add nav-toggle invert filter |
| `preview-src/ui-model.yml` | Add Widget Test page to dev tools nav |

## Preview Links

Test on mobile viewport (< 1024px width) or resize browser:

| Page | Link |
|------|------|
| Data Platform Landing | https://deploy-preview-381--docs-ui.netlify.app/home |
| Labs Home | https://deploy-preview-381--docs-ui.netlify.app/labs-home |

## Test Plan

- [ ] Open Data Platform landing on mobile (or resize browser < 1024px)
- [ ] Verify nav toggle icon is visible (white) against dark hero
- [ ] Test on Labs, Self-managed, Cloud, and Connect landing pages
- [ ] Test in Brave browser specifically