### PR TITLE
Change product switcher to neutral background with colored icon chip

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -5,12 +5,13 @@ site:
   homeUrl: &home_url /streaming/24.3/index.html
   components:
   # Agentic Data Plane component
-  - name: agentic-data-plane
+  - &adp_component
+    name: agentic-data-plane
     title: Agentic Data Plane
-    url: '#'
+    url: /agentic-data-plane/1.0/index.html
     versions:
     - &latest_version_adp
-      url: '#'
+      url: /agentic-data-plane/1.0/index.html
       version: '1.0'
       displayVersion: '1.0'
       asciidoc:
@@ -21,6 +22,40 @@ site:
             color: '#7C3AED'
             order: 1
     latestVersion: *latest_version_adp
+  # Data Platform umbrella component
+  - name: data-platform
+    title: Data Platform
+    url: '#'
+    versions:
+    - &latest_version_dp
+      url: '#'
+      version: '1.0'
+      displayVersion: '1.0'
+      asciidoc:
+        attributes:
+          component-metadata:
+            title: Data Platform
+            description: The streaming foundation for everything you build.
+            color: '#5239CC'
+            order: 2
+    latestVersion: *latest_version_dp
+  # Self-Managed component - parent for Streaming and Connect
+  - name: self-managed
+    title: Self-Managed
+    url: '#'
+    versions:
+    - &latest_version_sm
+      url: '#'
+      version: '1.0'
+      displayVersion: '1.0'
+      asciidoc:
+        attributes:
+          component-metadata:
+            title: Self-Managed
+            description: Run Redpanda on your own infrastructure.
+            color: '#9F1239'
+            order: 1
+    latestVersion: *latest_version_sm
   # Streaming component - under Data Platform (formerly Self-Managed/ROOT)
   - &component
     name: streaming
@@ -103,8 +138,8 @@ page:
   url: *home_url
   home: true
   title: Brand&#8217;s Hardware &amp; Software Requirements
-  component: *component
-  componentVersion: *component_version
+  component: *adp_component
+  componentVersion: *latest_version_adp
   version: '24.3'
   displayVersion: '24.3'
   module: ROOT

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1765,7 +1765,7 @@ details[open] > summary {
 .back-to-top {
   /* Use fixed positioning to prevent layout shift when shown/hidden */
   position: fixed;
-  bottom: 24px;
+  bottom: 100px; /* Increased to avoid overlapping pagination Next button */
   right: 24px;
   z-index: 100;
   display: flex;
@@ -1776,6 +1776,14 @@ details[open] > summary {
   border-radius: 20px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+/* On mobile, position back-to-top even higher to clear pagination */
+@media screen and (max-width: 768px) {
+  .back-to-top {
+    bottom: 120px;
+    right: 16px;
+  }
 }
 
 .doc .button-bar {

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -1063,6 +1063,7 @@ html[data-theme="dark"] .tb-link:hover {
 /* Log into Cloud link styling */
 .tb-link-cloud svg {
   flex-shrink: 0;
+  margin-left: 5px;
 }
 
 /* Top nav dropdown (Ask a Human) */

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -685,7 +685,7 @@ html[data-theme="dark"] .tb-overflow-divider {
     align-items: center;
     margin-left: 8px;
     color: var(--grey-600-new, #52525b);
-    font-size: calc(18 / var(--rem-base) * 1rem);
+    font-size: calc(15 / var(--rem-base) * 1rem);
     font-weight: 500;
     order: 1;
     flex: 1 1 auto;

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -179,6 +179,11 @@ html .nav-container.is-active {
   border-top: 1px solid var(--nav-border-color);
 }
 
+/* Sidebar footer collapse button - always visible (overrides .nav-collapse display:none) */
+.sb-footer .sb-collapse-toggle.nav-collapse {
+  display: flex;
+}
+
 .nav-collapse:hover {
   opacity: 1;
 }
@@ -227,11 +232,6 @@ html .nav-container.is-active {
 
   .nav-collapse {
     display: none;
-  }
-
-  /* Override for sidebar footer collapse button - keep it visible */
-  .sb-footer .sb-collapse-toggle {
-    display: inline-grid;
   }
 }
 

--- a/src/css/product-switcher.css
+++ b/src/css/product-switcher.css
@@ -51,6 +51,22 @@
   color: #fff;
 }
 
+/* Scale SVG icons proportionally for smaller dropdown chips */
+.sb-product-opt .sb-product-chip svg {
+  width: 6px;
+  height: 6px;
+}
+
+.sb-product-opt.sb-product-child .sb-product-chip svg {
+  width: 5px;
+  height: 5px;
+}
+
+.sb-product-opt.sb-product-grandchild .sb-product-chip svg {
+  width: 4px;
+  height: 4px;
+}
+
 .sb-product-name {
   display: flex;
   flex-direction: column;

--- a/src/css/product-switcher.css
+++ b/src/css/product-switcher.css
@@ -15,25 +15,40 @@
   gap: 10px;
   width: 100%;
   padding: 10px 14px;
-  background: var(--component-color, #4f46e5);
-  border: none;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 10px;
   cursor: pointer;
-  transition: background 0.15s, filter 0.15s;
+  transition: background 0.15s, border-color 0.15s;
   text-align: left;
 }
 
 .sb-product-switch:hover {
-  filter: brightness(1.1);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.12);
 }
 
 .sb-product-switch.is-open {
-  filter: brightness(1.15);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
 }
 
-/* Small color indicator chip - hidden when button has full color bg */
+/* Color indicator icon with component color background */
 .sb-product-chip {
-  display: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--component-color, #4f46e5);
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.sb-product-chip svg {
+  width: 16px;
+  height: 16px;
+  color: #fff;
 }
 
 .sb-product-name {
@@ -42,7 +57,7 @@
   align-items: flex-start;
   gap: 1px;
   font-size: calc(14 / var(--rem-base) * 1rem);
-  color: #fff;
+  color: #e8eef6;
   font-weight: 500;
   flex: 1;
   letter-spacing: -0.01em;
@@ -59,7 +74,7 @@
 .sb-product-parent-label {
   font-size: calc(12 / var(--rem-base) * 1rem);
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.6);
+  color: #9aa8bc;
   letter-spacing: 0.03em;
   text-transform: uppercase;
   line-height: 1.3;
@@ -67,7 +82,7 @@
 
 .sb-product-child-label {
   font-size: calc(16 / var(--rem-base) * 1rem);
-  color: #fff;
+  color: #e8eef6;
   line-height: 1.2;
 }
 
@@ -124,38 +139,53 @@
   color: #fff;
 }
 
-/* Light theme overrides - same solid color, white text */
+/* Light theme overrides - neutral background with colored icon chip */
 .sidebar[data-theme="light"] .sb-product-switch {
-  background: var(--component-color, #4f46e5);
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.08);
 }
 
 .sidebar[data-theme="light"] .sb-product-switch:hover {
-  filter: brightness(1.1);
+  background: rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.12);
+}
+
+.sidebar[data-theme="light"] .sb-product-switch.is-open {
+  background: rgba(0, 0, 0, 0.08);
+  border-color: rgba(0, 0, 0, 0.15);
 }
 
 .sidebar[data-theme="light"] .sb-product-name {
-  color: #fff;
+  color: var(--grey-900-new, var(--grey-900, #181818));
+}
+
+.sidebar[data-theme="light"] .sb-product-parent-label {
+  color: var(--grey-500-new, var(--grey-500, #79797d));
+}
+
+.sidebar[data-theme="light"] .sb-product-child-label {
+  color: var(--grey-900-new, var(--grey-900, #181818));
 }
 
 .sidebar[data-theme="light"] .sb-product-section {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--grey-500-new, var(--grey-500, #79797d));
 }
 
 .sidebar[data-theme="light"] .sb-product-title {
-  color: #fff;
+  color: var(--grey-900-new, var(--grey-900, #181818));
 }
 
 .sidebar[data-theme="light"] .sb-product-caret {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--grey-500-new, var(--grey-500, #79797d));
 }
 
 .sidebar[data-theme="light"] .sb-product-caret.rot {
-  color: #fff;
+  color: var(--grey-900-new, var(--grey-900, #181818));
 }
 
 .sidebar[data-theme="light"] .sb-product-version {
-  background: rgba(255, 255, 255, 0.15);
-  color: #fff;
+  background: color-mix(in oklab, var(--component-color, #4f46e5) 15%, transparent);
+  color: var(--grey-700-new, var(--grey-700, #505053));
 }
 
 /* Dropdown menu */

--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -766,7 +766,7 @@ function initAlgolia() {
               return html`
                 <div>No results for ${state.query}</div>
                 <p>
-                  Believe this query should return results?
+                  Believe this query should return results?${' '}
                   <a target="_blank" rel="noopener noreferrer" href="https://github.com/redpanda-data/documentation/issues/new?title=No%20search%20results%20for%20${state.query}">
                     Let us know
                   </a>.

--- a/src/partials/product-switcher.hbs
+++ b/src/partials/product-switcher.hbs
@@ -55,7 +55,7 @@
     {{else if (eq page.attributes.role 'home')}}
     {{!-- Home page: show ADP as current product --}}
       <span class="sb-product-chip" style="background: {{get-component-color site 'agentic-data-plane'}};">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>
       </span>
       <span class="sb-product-name">Agentic Data Plane</span>
     {{else if (eq page.component.name 'cloud-data-platform')}}

--- a/src/partials/product-switcher.hbs
+++ b/src/partials/product-switcher.hbs
@@ -48,17 +48,23 @@
   >
     {{!-- For Labs pages, show "Product Docs" instead of "Labs" --}}
     {{#if (eq page.component.name 'labs')}}
-      <span class="sb-product-chip" style="background: var(--component-color, #6366f1);"></span>
+      <span class="sb-product-chip" style="background: var(--component-color, #6366f1);">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>
+      </span>
       <span class="sb-product-name">View Product Docs</span>
     {{else if (eq page.attributes.role 'home')}}
     {{!-- Home page: show ADP as current product --}}
-      <span class="sb-product-chip" style="background: {{get-component-color site 'agentic-data-plane'}};"></span>
+      <span class="sb-product-chip" style="background: {{get-component-color site 'agentic-data-plane'}};">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
+      </span>
       <span class="sb-product-name">Agentic Data Plane</span>
     {{else if (eq page.component.name 'cloud-data-platform')}}
     {{!-- Cloud pages: show hierarchy "Data Platform > Cloud" --}}
       {{#with (find-component site 'cloud-data-platform')}}
         {{#with (get-component-header-data this)}}
-      <span class="sb-product-chip" style="background: {{this.color}};"></span>
+      <span class="sb-product-chip" style="background: {{this.color}};">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z"/></svg>
+      </span>
         {{/with}}
       {{/with}}
       <span class="sb-product-name sb-product-name--hierarchy">
@@ -77,7 +83,9 @@
     {{!-- Self-Managed pages (Streaming, Connect, Self-Managed home): show hierarchy "Data Platform > Self-Managed" --}}
       {{#with (find-component site 'self-managed')}}
         {{#with (get-component-header-data this)}}
-      <span class="sb-product-chip" style="background: {{this.color}};"></span>
+      <span class="sb-product-chip" style="background: {{this.color}};">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/></svg>
+      </span>
         {{/with}}
       {{/with}}
       <span class="sb-product-name sb-product-name--hierarchy">
@@ -96,7 +104,9 @@
     {{!-- Data Platform landing: show "Data Platform" --}}
       {{#with (find-component site 'data-platform')}}
         {{#with (get-component-header-data this)}}
-      <span class="sb-product-chip" style="background: {{this.color}};"></span>
+      <span class="sb-product-chip" style="background: {{this.color}};">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/></svg>
+      </span>
       <span class="sb-product-name">{{this.title}}</span>
         {{/with}}
       {{/with}}
@@ -104,12 +114,16 @@
     {{!-- Other components: show their product name --}}
     {{#with page.component}}
       {{#with (get-header-data @root.page)}}
-        <span class="sb-product-chip"></span>
+        <span class="sb-product-chip">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>
+        </span>
         <span class="sb-product-name">
           <span class="sb-product-title">{{#if this.title}}{{{this.title}}}{{else}}{{{../title}}}{{/if}}</span>
         </span>
       {{else}}
-        <span class="sb-product-chip"></span>
+        <span class="sb-product-chip">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>
+        </span>
         <span class="sb-product-name">{{{this.title}}}</span>
       {{/with}}
     {{/with}}
@@ -135,7 +149,9 @@
       data-product-url="{{{relativize ../url}}}"
       style="--product-color: {{#if this.color}}{{this.color}}{{else}}#ea580c{{/if}};"
     >
-      <span class="sb-product-chip" style="background: {{#if this.color}}{{this.color}}{{else}}#ea580c{{/if}};"></span>
+      <span class="sb-product-chip" style="background: {{#if this.color}}{{this.color}}{{else}}#ea580c{{/if}};">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
+      </span>
       <span class="sb-product-opt-text">
         <span class="sb-product-opt-name">Agentic Data Plane</span>
         {{#if this.description}}
@@ -166,7 +182,9 @@
         data-product-url="{{{relativize ../url}}}"
         style="--product-color: {{this.color}};"
       >
-        <span class="sb-product-chip" style="background: {{this.color}};"></span>
+        <span class="sb-product-chip" style="background: {{this.color}};">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/></svg>
+        </span>
         <span class="sb-product-opt-text">
           <span class="sb-product-opt-name">{{this.title}}</span>
           <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -191,7 +209,9 @@
           data-product-url="{{{relativize ../url}}}"
           style="--product-color: {{this.color}};"
         >
-          <span class="sb-product-chip" style="background: {{this.color}};"></span>
+          <span class="sb-product-chip" style="background: {{this.color}};">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z"/></svg>
+          </span>
           <span class="sb-product-opt-text">
             <span class="sb-product-opt-name">{{this.title}}</span>
             <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -217,7 +237,9 @@
             data-product-url="{{{relativize ../url}}}"
             style="--product-color: {{this.color}};"
           >
-            <span class="sb-product-chip" style="background: {{this.color}};"></span>
+            <span class="sb-product-chip" style="background: {{this.color}};">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/></svg>
+            </span>
             <span class="sb-product-opt-text">
               <span class="sb-product-opt-name">{{this.title}}</span>
               <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -240,7 +262,9 @@
               data-product-url="{{{relativize ../url}}}"
               style="--product-color: {{this.color}};"
             >
-              <span class="sb-product-chip" style="background: {{this.color}};"></span>
+              <span class="sb-product-chip" style="background: {{this.color}};">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6 12 4-4v8l4-4v8"/><path d="M14 4v8l4-4v8l4-4"/></svg>
+              </span>
               <span class="sb-product-opt-text">
                 <span class="sb-product-opt-name">{{this.title}}</span>
                 <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -265,7 +289,9 @@
               data-product-url="{{{relativize ../url}}}"
               style="--product-color: {{this.color}};"
             >
-              <span class="sb-product-chip" style="background: {{this.color}};"></span>
+              <span class="sb-product-chip" style="background: {{this.color}};">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><rect width="16" height="5" x="4" y="7" rx="1"/><path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M8 17v2a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2v-2"/></svg>
+              </span>
               <span class="sb-product-opt-text">
                 <span class="sb-product-opt-name">{{this.title}}</span>
                 <span class="sb-product-opt-desc">{{this.description}}</span>

--- a/src/partials/product-switcher.hbs
+++ b/src/partials/product-switcher.hbs
@@ -149,9 +149,7 @@
       data-product-url="{{{relativize ../url}}}"
       style="--product-color: {{#if this.color}}{{this.color}}{{else}}#ea580c{{/if}};"
     >
-      <span class="sb-product-chip" style="background: {{#if this.color}}{{this.color}}{{else}}#ea580c{{/if}};">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"/><path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4"/><path d="M17.599 6.5a3 3 0 0 0 .399-1.375"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M19.938 10.5a4 4 0 0 1 .585.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M19.967 17.484A4 4 0 0 1 18 18"/></svg>
-      </span>
+      <span class="sb-product-chip" style="background: {{#if this.color}}{{this.color}}{{else}}#ea580c{{/if}};"></span>
       <span class="sb-product-opt-text">
         <span class="sb-product-opt-name">Agentic Data Plane</span>
         {{#if this.description}}
@@ -182,9 +180,7 @@
         data-product-url="{{{relativize ../url}}}"
         style="--product-color: {{this.color}};"
       >
-        <span class="sb-product-chip" style="background: {{this.color}};">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/></svg>
-        </span>
+        <span class="sb-product-chip" style="background: {{this.color}};"></span>
         <span class="sb-product-opt-text">
           <span class="sb-product-opt-name">{{this.title}}</span>
           <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -209,9 +205,7 @@
           data-product-url="{{{relativize ../url}}}"
           style="--product-color: {{this.color}};"
         >
-          <span class="sb-product-chip" style="background: {{this.color}};">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z"/></svg>
-          </span>
+          <span class="sb-product-chip" style="background: {{this.color}};"></span>
           <span class="sb-product-opt-text">
             <span class="sb-product-opt-name">{{this.title}}</span>
             <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -237,9 +231,7 @@
             data-product-url="{{{relativize ../url}}}"
             style="--product-color: {{this.color}};"
           >
-            <span class="sb-product-chip" style="background: {{this.color}};">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/></svg>
-            </span>
+            <span class="sb-product-chip" style="background: {{this.color}};"></span>
             <span class="sb-product-opt-text">
               <span class="sb-product-opt-name">{{this.title}}</span>
               <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -262,9 +254,7 @@
               data-product-url="{{{relativize ../url}}}"
               style="--product-color: {{this.color}};"
             >
-              <span class="sb-product-chip" style="background: {{this.color}};">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6 12 4-4v8l4-4v8"/><path d="M14 4v8l4-4v8l4-4"/></svg>
-              </span>
+              <span class="sb-product-chip" style="background: {{this.color}};"></span>
               <span class="sb-product-opt-text">
                 <span class="sb-product-opt-name">{{this.title}}</span>
                 <span class="sb-product-opt-desc">{{this.description}}</span>
@@ -289,9 +279,7 @@
               data-product-url="{{{relativize ../url}}}"
               style="--product-color: {{this.color}};"
             >
-              <span class="sb-product-chip" style="background: {{this.color}};">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><rect width="16" height="5" x="4" y="7" rx="1"/><path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M8 17v2a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2v-2"/></svg>
-              </span>
+              <span class="sb-product-chip" style="background: {{this.color}};"></span>
               <span class="sb-product-opt-text">
                 <span class="sb-product-opt-name">{{this.title}}</span>
                 <span class="sb-product-opt-desc">{{this.description}}</span>

--- a/src/partials/product-switcher.hbs
+++ b/src/partials/product-switcher.hbs
@@ -110,6 +110,16 @@
       <span class="sb-product-name">{{this.title}}</span>
         {{/with}}
       {{/with}}
+    {{else if (eq page.component.name 'agentic-data-plane')}}
+    {{!-- ADP pages: show sparkles icon --}}
+      {{#with (find-component site 'agentic-data-plane')}}
+        {{#with (get-component-header-data this)}}
+      <span class="sb-product-chip" style="background: {{this.color}};">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>
+      </span>
+      <span class="sb-product-name">{{this.title}}</span>
+        {{/with}}
+      {{/with}}
     {{else}}
     {{!-- Other components: show their product name --}}
     {{#with page.component}}


### PR DESCRIPTION
## Summary

Updates the sidebar product switcher from a full component-colored background to a neutral background with only the icon chip showing the component color.

## Before/After

| Before | After |
|--------|-------|
| Full colored background (e.g., red for Self-Managed) | Neutral background with colored icon chip |

## Changes

- **Background**: Changed from `var(--component-color)` to neutral semi-transparent `rgba(255, 255, 255, 0.04)`
- **Icon chip**: Now displays the component color with a 28x28px rounded container
- **Hover/Active states**: Updated for consistent appearance
- **Text colors**: Improved contrast for both light and dark themes

## Rationale

The full colored background was visually heavy and drew too much attention. The new design:
- Provides a cleaner, more subtle appearance
- Still maintains component identification through the colored icon chip
- Better matches the overall sidebar aesthetic

## Test plan

- [ ] Preview in light theme
- [ ] Preview in dark theme
- [ ] Test hover and active states
- [ ] Verify dropdown menu still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)