### PR TITLE
Fix beta badge cursor and add default tooltip

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -443,7 +443,11 @@ html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-caret {
   font-weight: 600;
   letter-spacing: 0.02em;
   white-space: nowrap;
-  cursor: default;
+}
+
+/* Show help cursor when badge has tooltip */
+.status-badge[data-tippy-content] {
+  cursor: help;
 }
 
 .status-badge svg {

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -26,7 +26,7 @@
     {{> version-selector}}
     {{!-- Status badges: Beta, Limited Availability --}}
     {{#if page.attributes.beta}}
-    <span class="status-badge status-badge--beta" {{#if page.attributes.beta-text}}data-tippy-content="{{page.attributes.beta-text}}"{{/if}}>beta</span>
+    <span class="status-badge status-badge--beta" data-tippy-content="{{#if page.attributes.beta-text}}{{page.attributes.beta-text}}{{else}}This feature is in beta and may change.{{/if}}">beta</span>
     {{/if}}
     {{#if page.attributes.limited-availability}}
     <span class="status-badge status-badge--la" {{#if page.attributes.limited-availability-text}}data-tippy-content="{{page.attributes.limited-availability-text}}"{{/if}}>
@@ -123,7 +123,7 @@
     const betaBadge = stickyHeader?.querySelector(".status-badge--beta");
     const navBetaBadge = navMetadataContainer?.querySelector(".nav-beta-label");
 
-    if (betaBadge && betaBadge.dataset.tippyContent) {
+    if (betaBadge) {
       tippy(betaBadge, {
         content: betaBadge.dataset.tippyContent,
         animation: "scale",


### PR DESCRIPTION
## Summary
- Change cursor to `help` for status badges with tooltips (was `default`)
- Add default tooltip text for beta badges: "This feature is in beta and may change."
- Remove conditional check so tooltip always initializes when badge is present

## Test plan
- [ ] View a page with `:beta: true` attribute
- [ ] Verify cursor shows as help pointer on hover
- [ ] Verify tooltip appears with default text
- [ ] Test with custom `:beta-text:` to ensure it still overrides default