### PR TITLE
Use new Redpanda logo in mobile top nav

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -19,7 +19,7 @@
     <div class="navbar-brand" id="brand">
       {{#with site.homeUrl}}
       <a class="navbar-item mobile-logo" href="{{{relativize this}}}" aria-label="Go to home page">
-        <img src="{{{@root.uiRootPath}}}/img/Redpanda_Favicon_32px.svg" width="28" height="28" alt="Redpanda"/>
+        <img src="{{{@root.uiRootPath}}}/img/footer-logo.svg" width="28" height="24" alt="Redpanda"/>
       </a>
       {{/with}}
       <span class="platform-indicator-mobile">{{page.component.title}}</span>


### PR DESCRIPTION
## Problem

On mobile, the top nav displayed the old "R" logo (`Redpanda_Favicon_32px.svg`, from 2023) instead of the current logo. The desktop sidebar and footer already use the new geometric mark (`footer-logo.svg`).

## Fix

Swap the mobile logo in `src/partials/header-content.hbs` to `footer-logo.svg` (with matching `width="28" height="24"`), so branding is consistent across viewports.

## Testing

- `gulp preview`, resize to a mobile viewport (or http://localhost:5252) and confirm the new logo renders in the top nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)