### PR TITLE
Fix: Bloblang playground title hidden behind sticky bar on mobile

### DIFF
--- a/src/css/bloblang-playground.css
+++ b/src/css/bloblang-playground.css
@@ -846,6 +846,13 @@ html[data-theme=dark] .bloblang-snippet .ace-editor {
     overflow: visible;
   }
 
+  /* The sticky product indicator (position: sticky, z-index: 50, opaque
+     background) otherwise overlaps and hides the page title on narrow screens.
+     Keep it in normal flow here so the title sits cleanly below it. */
+  .bloblang-playground .component-indicator-sticky {
+    position: static;
+  }
+
   /* Ensure page title is visible on mobile */
   .bloblang-playground .doc h1.page {
     display: block !important;


### PR DESCRIPTION
## Problem
On mobile (≤1024px), the Bloblang playground page title ("Bloblang Playground") is invisible — hidden behind the sticky product indicator (`.component-indicator-sticky`), which has `z-index: 50` and an opaque background and overlaps the same vertical band as the `h1.page` title.

The title element itself renders fine (white, `visibility: visible`, `z-index: 1`) — it's just painted over by the higher-z, opaque sticky bar.

## Fix
Keep the product indicator in normal flow (`position: static`) on the playground at ≤1024px, so the title sits cleanly below it. Scoped to `.bloblang-playground`, so it only affects this app-like page — losing sticky-on-scroll for the indicator there is a fine tradeoff.

## Scope
Pre-existing bug, unrelated to the Ask AI work — one scoped CSS rule in `bloblang-playground.css`. Verified on a 390px viewport: title now visible below the indicator, no overlap (sticky 210–262, title 274–303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)