### PR TITLE
Fix missing click analytics on /search/ results page

### DIFF
--- a/src/layouts/search.hbs
+++ b/src/layouts/search.hbs
@@ -62,17 +62,25 @@
         const searchClient = {
           ...baseClient,
           search(requests) {
-            if (exactMatch) {
-              requests = requests.map((request) => {
-                const params = { ...(request.params || {}) };
-                if (params.query) {
-                  params.typoTolerance = false;
-                  params.removeWordsIfNoResults = 'none';
-                  params.optionalWords = [];
-                }
-                return { ...request, params };
-              });
-            }
+            requests = requests.map((request) => {
+              const params = { ...(request.params || {}) };
+              // Keep empty "root" queries out of Algolia Search analytics. These
+              // fire on initial page load and during facet-only browsing (no term
+              // typed). They still return results, but `analytics: false` stops
+              // them being recorded as a searched term — otherwise they show up as
+              // "<empty search>" and dominate the report and skew average CTR.
+              if (!params.query) {
+                params.analytics = false;
+              }
+              // Exact match: require every term, exact spelling, no optional-word
+              // fallback. Only meaningful when there's an actual query.
+              if (exactMatch && params.query) {
+                params.typoTolerance = false;
+                params.removeWordsIfNoResults = 'none';
+                params.optionalWords = [];
+              }
+              return { ...request, params };
+            });
             return baseClient.search(requests);
           },
         };
@@ -81,6 +89,12 @@
         const search = instantsearch({
           searchClient,
           indexName,
+          // Enable click/conversion analytics. Reuses the global `aa`
+          // (search-insights) already initialised in algolia-script.hbs, sets
+          // clickAnalytics on queries, and attaches a queryID so the click
+          // events we send below are attributed to the search that produced them.
+          // https://www.algolia.com/doc/api-reference/widgets/insights/js/
+          insights: true,
           routing: {
             stateMapping: {
               // Convert UI state to URL parameters
@@ -137,18 +151,23 @@
           instantsearch.widgets.hits({
             container: '.results',
             templates: {
-              item: (hit, { html, components }) => {
+              item: (hit, { html, components, sendEvent }) => {
+                // Record a click event attributed to the current query (queryID)
+                // so Algolia can report CTR/CVR for the results page. Uses
+                // navigator.sendBeacon under the hood, so it survives the
+                // navigation triggered by the link.
+                const onHitClick = () => sendEvent('click', hit, 'Hit Clicked');
                 const isExternal = hit.objectID.startsWith('https');
                 if (isExternal) {
                   return html`
                     <div class="card">
                       <h2 class="ais-Heading">
-                        <a href="${hit.objectID}" target="_blank">
+                        <a href="${hit.objectID}" target="_blank" onClick=${onHitClick}>
                           ${components.Highlight({ attribute: 'title', hit })}
                         </a>
                       </h2>
                       <p>
-                        <a href="${hit.objectID}">
+                        <a href="${hit.objectID}" onClick=${onHitClick}>
                           ${components.Snippet({ attribute: 'intro', hit })}
                         </a>
                       </p>
@@ -164,10 +183,10 @@
                 return html`
                   <div class="card">
                     <h2 class="ais-Heading">
-                      <a href="${hit.objectID}">${components.Highlight({ attribute: 'title', hit })}</a>
+                      <a href="${hit.objectID}" onClick=${onHitClick}>${components.Highlight({ attribute: 'title', hit })}</a>
                     </h2>
                     <p>
-                      <a href="${hit.objectID}">${components.Snippet({ attribute: 'intro', hit })}</a>
+                      <a href="${hit.objectID}" onClick=${onHitClick}>${components.Snippet({ attribute: 'intro', hit })}</a>
                     </p>
                     <div class="aa-ItemContentRow">
                       <div class="aa-ItemContentTitle result-type">${hit.type}</div>


### PR DESCRIPTION
## Problem

Algolia **Click & Conversion analytics** showed little/no click data for docs search (CTR/CVR mostly N/A or 0%), and the top queries were dominated by two odd rows: `<empty search>` (~33% of searches) and `{search_term_string}`.

Root cause: we have **two** Algolia surfaces and only one was instrumented.

- **Autocomplete dropdown** (`src/partials/algolia-script.hbs`) — fully wired: `search-insights`, `aa('init')`, `insights: true`, `clickAnalytics: true`, and `clickedObjectIDsAfterSearch` with `queryID`. ✅
- **Standalone `/search/` results page** (`src/layouts/search.hbs`) — InstantSearch with **no insights, no `clickAnalytics`, and no click events sent**. Every click from the full results page was invisible to Algolia. ❌

Since the bulk of "real" searching happens on `/search/`, most click data was missing and CVR sat at 0%.

## Changes (`src/layouts/search.hbs`)

1. **Enable `insights: true`** on the InstantSearch instance. It reuses the global `aa` (search-insights) already initialised in `algolia-script.hbs` with matching `ALGOLIA_APP_ID`/`ALGOLIA_API_KEY`, sets `clickAnalytics`, and attaches a `queryID` to each query.
2. **Wire `sendEvent('click', hit, 'Hit Clicked')`** into the custom hit-template links. Custom `hits` templates don't get automatic click tracking, so this is required for clicks to record and attribute to the query. `sendEvent` uses `navigator.sendBeacon`, so it survives the navigation the link triggers.
3. **Suppress empty "root" queries from analytics** via `analytics: false`. These fire on initial page load and during facet-only browsing (no term typed) and were logged as `<empty search>` (~33% of searches), dominating the report and skewing average CTR. Results still return — they're just not counted as a searched term. Using `analytics: false` (rather than blocking the request) preserves initial load and facet-only browsing.

## Not changed

The `{search_term_string}` query (low volume, no clicks) is the sitelinks-searchbox `SearchAction` template in `src/partials/head-structured-data.hbs` (`/search/?q={search_term_string}`) being crawled literally by Google/bots. That's expected SEO behavior — left as-is; filter it out in the dashboard view if desired.

## Testing

- `gulp lint` passes.
- Manual verification recommended on a deploy preview: perform a search on `/search/`, click a result, and confirm a `Hit Clicked` event appears in Algolia (Events debugger / Click analytics), and that a blank `/search/` load no longer records an `<empty search>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)