### PR TITLE
Fix Bloblang CI failing on missing Puppeteer Chrome

### DIFF
--- a/.github/workflows/test-bloblang-playground.yml
+++ b/.github/workflows/test-bloblang-playground.yml
@@ -48,6 +48,14 @@ jobs:
     - name: Install npm dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm ci
+    - name: Cache Puppeteer browsers
+      id: cache-puppeteer
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/puppeteer
+        key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+    - name: Install Chrome for Puppeteer
+      run: npx puppeteer browsers install chrome
     - name: Setup Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/test-bloblang-playground.yml
+++ b/.github/workflows/test-bloblang-playground.yml
@@ -55,7 +55,23 @@ jobs:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
     - name: Install Chrome for Puppeteer
-      run: npx puppeteer browsers install chrome
+      run: |
+        # Install Chrome and pin Puppeteer to the exact binary path the installer
+        # reports. On a node_modules cache hit, `npm ci` (and Puppeteer's
+        # postinstall) is skipped, and Puppeteer's launch-time cache-dir
+        # resolution then fails to locate the browser even though it is present.
+        # Setting PUPPETEER_EXECUTABLE_PATH makes launch() use this binary directly.
+        install_output="$(npx puppeteer browsers install chrome)"
+        echo "$install_output"
+        # Installer prints "chrome@<version> <path>"; strip the prefix so paths
+        # containing spaces are preserved.
+        chrome_path="$(echo "$install_output" | sed -n 's/^chrome@[^ ]* //p' | tail -n1)"
+        if [ ! -x "$chrome_path" ]; then
+          echo "::error::Chrome binary not found at reported path: '$chrome_path'"
+          exit 1
+        fi
+        echo "PUPPETEER_EXECUTABLE_PATH=$chrome_path" >> "$GITHUB_ENV"
+        echo "Using PUPPETEER_EXECUTABLE_PATH=$chrome_path"
     - name: Setup Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
## Problem

The **Bloblang Tests** workflow keeps failing on the *Build and Test Playground* step — but it is not a test failure. The Puppeteer-based test runner cannot find a browser to launch:

\`\`\`
❌ Test execution failed: Could not find Chrome (ver. 121.0.6167.85).
   ... your cache path is ... /home/runner/.cache/puppeteer
\`\`\`

## Root cause

Puppeteer downloads its Chrome binary into `~/.cache/puppeteer` as a **postinstall step of `npm ci`** — not into `node_modules`. The workflow had a caching gap:

1. It cached **only `node_modules`**, not `~/.cache/puppeteer`.
2. `npm ci` was gated on a cache miss (`if: steps.cache-node-modules.outputs.cache-hit != 'true'`).

Once the `node_modules` cache was warm, `npm ci` was permanently skipped → Puppeteer's postinstall never ran → Chrome was never present → **every** subsequent run failed on browser launch. This is why it kept failing rather than being flaky.

## Fix

- Add an explicit **Install Chrome for Puppeteer** step (`npx puppeteer browsers install chrome`) that runs unconditionally, guaranteeing the browser exists before the tests launch it — independent of the `node_modules` cache.
- Add a dedicated cache for `~/.cache/puppeteer` so the install stays a fast no-op on cache hits.