### PR TITLE
Fix version dropdown links/labels and code-block styling

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -99,6 +99,7 @@ site:
     - url: '#'
       version: '5.0'
       displayVersion: '5.0'
+    latest: *latest_version_xyz
     latestVersion: *latest_version_xyz
   # Cloud component - under Data Platform
   - &cloud_component

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -197,6 +197,10 @@ page:
     url: /streaming/24.3/index.html
     urlType: internal
   versions:
+  - version: '7.0'
+    displayVersion: '7.0 Beta'
+    prerelease: true
+    url: '#'
   - version: '6.0'
     displayVersion: '6.0'
     url: '#'

--- a/src/css/component-home-v3.css
+++ b/src/css/component-home-v3.css
@@ -196,8 +196,8 @@ html[data-theme=dark] .ch3-hero::after {
 }
 
 .sm-ver-pill-dot[data-status="beta"] {
-  background: #818cf8;
-  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.2);
+  background: #fbbf24;
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.2);
 }
 
 .sm-ver-pill-label {
@@ -241,7 +241,7 @@ html[data-theme=dark] .ch3-hero::after {
 }
 
 .sm-ver-pill-status[data-status="beta"] {
-  color: #a5b4fc;
+  color: #fcd34d;
 }
 
 /* Light mode: darker colors for visibility on light backgrounds */
@@ -258,7 +258,7 @@ html:not([data-theme=dark]) .sm-ver-pill-status[data-status="eol"] {
 }
 
 html:not([data-theme=dark]) .sm-ver-pill-status[data-status="beta"] {
-  color: #444ce7;
+  color: #92400e;
 }
 
 .sm-ver-pill-caret {
@@ -491,12 +491,12 @@ html:not([data-theme=dark]) .sm-ver-pill-caret {
 }
 
 .sm-ver-row-status[data-status="beta"] {
-  color: #3730a3;
-  background: rgba(68, 76, 231, 0.1);
+  color: #92400e;
+  background: #fef3c7;
 }
 
 .sm-ver-row[data-status="beta"] .sm-ver-row-note {
-  color: #444ce7;
+  color: #b45309;
 }
 
 .sm-ver-row-check {
@@ -625,12 +625,12 @@ html[data-theme="dark"] .sm-ver-row-status[data-status="eol"] {
 }
 
 html[data-theme="dark"] .sm-ver-row-status[data-status="beta"] {
-  color: #a5b4fc;
-  background: rgba(129, 140, 248, 0.15);
+  color: #fcd34d;
+  background: rgba(251, 191, 36, 0.15);
 }
 
 html[data-theme="dark"] .sm-ver-row[data-status="beta"] .sm-ver-row-note {
-  color: #a5b4fc;
+  color: #fcd34d;
 }
 
 html[data-theme="dark"] .sm-ver-row-date-l {

--- a/src/css/component-home-v3.css
+++ b/src/css/component-home-v3.css
@@ -196,8 +196,8 @@ html[data-theme=dark] .ch3-hero::after {
 }
 
 .sm-ver-pill-dot[data-status="beta"] {
-  background: #fbbf24;
-  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.2);
+  background: #c084fc;
+  box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.2);
 }
 
 .sm-ver-pill-label {
@@ -241,7 +241,7 @@ html[data-theme=dark] .ch3-hero::after {
 }
 
 .sm-ver-pill-status[data-status="beta"] {
-  color: #fcd34d;
+  color: #c4b5fd;
 }
 
 /* Light mode: darker colors for visibility on light backgrounds */
@@ -258,7 +258,7 @@ html:not([data-theme=dark]) .sm-ver-pill-status[data-status="eol"] {
 }
 
 html:not([data-theme=dark]) .sm-ver-pill-status[data-status="beta"] {
-  color: #92400e;
+  color: #7c3aed;
 }
 
 .sm-ver-pill-caret {
@@ -491,12 +491,12 @@ html:not([data-theme=dark]) .sm-ver-pill-caret {
 }
 
 .sm-ver-row-status[data-status="beta"] {
-  color: #92400e;
-  background: #fef3c7;
+  color: #5b21b6;
+  background: #ede9fe;
 }
 
 .sm-ver-row[data-status="beta"] .sm-ver-row-note {
-  color: #b45309;
+  color: #7c3aed;
 }
 
 .sm-ver-row-check {
@@ -625,12 +625,12 @@ html[data-theme="dark"] .sm-ver-row-status[data-status="eol"] {
 }
 
 html[data-theme="dark"] .sm-ver-row-status[data-status="beta"] {
-  color: #fcd34d;
-  background: rgba(251, 191, 36, 0.15);
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.15);
 }
 
 html[data-theme="dark"] .sm-ver-row[data-status="beta"] .sm-ver-row-note {
-  color: #fcd34d;
+  color: #c4b5fd;
 }
 
 html[data-theme="dark"] .sm-ver-row-date-l {

--- a/src/css/component-home-v3.css
+++ b/src/css/component-home-v3.css
@@ -196,8 +196,8 @@ html[data-theme=dark] .ch3-hero::after {
 }
 
 .sm-ver-pill-dot[data-status="beta"] {
-  background: #a78bfa;
-  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.2);
+  background: #818cf8;
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.2);
 }
 
 .sm-ver-pill-label {
@@ -241,7 +241,7 @@ html[data-theme=dark] .ch3-hero::after {
 }
 
 .sm-ver-pill-status[data-status="beta"] {
-  color: #c4b5fd;
+  color: #a5b4fc;
 }
 
 /* Light mode: darker colors for visibility on light backgrounds */
@@ -258,7 +258,7 @@ html:not([data-theme=dark]) .sm-ver-pill-status[data-status="eol"] {
 }
 
 html:not([data-theme=dark]) .sm-ver-pill-status[data-status="beta"] {
-  color: #7c3aed;
+  color: #444ce7;
 }
 
 .sm-ver-pill-caret {
@@ -491,12 +491,12 @@ html:not([data-theme=dark]) .sm-ver-pill-caret {
 }
 
 .sm-ver-row-status[data-status="beta"] {
-  color: #6d28d9;
-  background: rgba(124, 58, 237, 0.1);
+  color: #3730a3;
+  background: rgba(68, 76, 231, 0.1);
 }
 
 .sm-ver-row[data-status="beta"] .sm-ver-row-note {
-  color: #7c3aed;
+  color: #444ce7;
 }
 
 .sm-ver-row-check {
@@ -625,12 +625,12 @@ html[data-theme="dark"] .sm-ver-row-status[data-status="eol"] {
 }
 
 html[data-theme="dark"] .sm-ver-row-status[data-status="beta"] {
-  color: #c4b5fd;
-  background: rgba(167, 139, 250, 0.15);
+  color: #a5b4fc;
+  background: rgba(129, 140, 248, 0.15);
 }
 
 html[data-theme="dark"] .sm-ver-row[data-status="beta"] .sm-ver-row-note {
-  color: #c4b5fd;
+  color: #a5b4fc;
 }
 
 html[data-theme="dark"] .sm-ver-row-date-l {

--- a/src/css/component-home-v3.css
+++ b/src/css/component-home-v3.css
@@ -195,6 +195,11 @@ html[data-theme=dark] .ch3-hero::after {
   box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
 }
 
+.sm-ver-pill-dot[data-status="beta"] {
+  background: #a78bfa;
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.2);
+}
+
 .sm-ver-pill-label {
   font-size: calc(13 / var(--rem-base) * 1rem);
   font-weight: 500;
@@ -235,6 +240,10 @@ html[data-theme=dark] .ch3-hero::after {
   color: #fcd34d;
 }
 
+.sm-ver-pill-status[data-status="beta"] {
+  color: #c4b5fd;
+}
+
 /* Light mode: darker colors for visibility on light backgrounds */
 html:not([data-theme=dark]) .sm-ver-pill-status[data-status="current"] {
   color: #059669;
@@ -246,6 +255,10 @@ html:not([data-theme=dark]) .sm-ver-pill-status[data-status="supported"] {
 
 html:not([data-theme=dark]) .sm-ver-pill-status[data-status="eol"] {
   color: #d97706;
+}
+
+html:not([data-theme=dark]) .sm-ver-pill-status[data-status="beta"] {
+  color: #7c3aed;
 }
 
 .sm-ver-pill-caret {
@@ -477,6 +490,15 @@ html:not([data-theme=dark]) .sm-ver-pill-caret {
   background: rgba(245, 158, 11, 0.1);
 }
 
+.sm-ver-row-status[data-status="beta"] {
+  color: #6d28d9;
+  background: rgba(124, 58, 237, 0.1);
+}
+
+.sm-ver-row[data-status="beta"] .sm-ver-row-note {
+  color: #7c3aed;
+}
+
 .sm-ver-row-check {
   display: inline-flex;
   align-items: center;
@@ -600,6 +622,15 @@ html[data-theme="dark"] .sm-ver-row-status[data-status="supported"] {
 html[data-theme="dark"] .sm-ver-row-status[data-status="eol"] {
   color: #fcd34d;
   background: rgba(245, 158, 11, 0.15);
+}
+
+html[data-theme="dark"] .sm-ver-row-status[data-status="beta"] {
+  color: #c4b5fd;
+  background: rgba(167, 139, 250, 0.15);
+}
+
+html[data-theme="dark"] .sm-ver-row[data-status="beta"] .sm-ver-row-note {
+  color: #c4b5fd;
 }
 
 html[data-theme="dark"] .sm-ver-row-date-l {

--- a/src/css/doc-bump.css
+++ b/src/css/doc-bump.css
@@ -223,11 +223,10 @@ html[data-theme=dark] {
 
 .aa-DetachedOverlay .doc pre > code,
 .aa-DetachedOverlay .doc details .listingblock .content pre > code {
-  padding-bottom: 1rem;
   border: none;
   white-space: pre-wrap;
   font-weight: lighter;
-  line-height: 1.7;
+  line-height: 1.5;
 }
 
 .aa-DetachedOverlay .doc blockquote {
@@ -1076,6 +1075,7 @@ html[data-theme=dark] {
 
 .aa-DetachedOverlay .doc .source-toolbox {
   display: flex;
+  align-items: center;
   visibility: hidden;
   position: absolute;
   top: 0.25rem;
@@ -1086,6 +1086,16 @@ html[data-theme=dark] {
   line-height: 1.5;
   white-space: nowrap;
   z-index: 1;
+  /* Toolbox floats over the code on hover - backdrop keeps it legible */
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--grey-50-new, #f9fafb);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+
+html[data-theme="dark"] .aa-DetachedOverlay .doc .source-toolbox {
+  background: #182236;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .aa-DetachedOverlay .doc .listingblock:hover .source-toolbox {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -372,7 +372,7 @@ html[data-theme="dark"] .component-indicator-sticky .context-dropdown-item:focus
 }
 
 .component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
-  color: #7c3aed;
+  color: #444ce7;
 }
 
 .component-indicator-sticky .sm-ver-pill-caret {
@@ -407,7 +407,7 @@ html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-sta
 }
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
-  color: #c4b5fd;
+  color: #9184f1;
 }
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-caret {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -372,7 +372,7 @@ html[data-theme="dark"] .component-indicator-sticky .context-dropdown-item:focus
 }
 
 .component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
-  color: #444ce7;
+  color: #92400e;
 }
 
 .component-indicator-sticky .sm-ver-pill-caret {
@@ -407,7 +407,7 @@ html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-sta
 }
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
-  color: #9184f1;
+  color: #fcd34d;
 }
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-caret {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -372,7 +372,7 @@ html[data-theme="dark"] .component-indicator-sticky .context-dropdown-item:focus
 }
 
 .component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
-  color: #92400e;
+  color: #7c3aed;
 }
 
 .component-indicator-sticky .sm-ver-pill-caret {
@@ -407,7 +407,7 @@ html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-sta
 }
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
-  color: #fcd34d;
+  color: #c4b5fd;
 }
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-caret {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -371,6 +371,10 @@ html[data-theme="dark"] .component-indicator-sticky .context-dropdown-item:focus
   color: #d97706;
 }
 
+.component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
+  color: #7c3aed;
+}
+
 .component-indicator-sticky .sm-ver-pill-caret {
   color: var(--grey-500-new, #737373);
 }
@@ -400,6 +404,10 @@ html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-sta
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-status="eol"] {
   color: #fcd34d;
+}
+
+html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-status[data-status="beta"] {
+  color: #c4b5fd;
 }
 
 html[data-theme="dark"] .component-indicator-sticky .sm-ver-pill-caret {
@@ -699,10 +707,10 @@ html[data-theme="dark"] .status-badge--cloud {
 
 .doc pre {
   font-size: calc(15 / var(--rem-base) * 1rem);
-  line-height: 1.65;
+  line-height: 1.5;
   margin: 0;
   padding: 16px 18px;
-  padding-top: 40px; /* Extra space for toolbar */
+  border: none; /* Frame is drawn by .listingblock > .content */
   color: var(--grey-800-new, #1f2937); /* Light mode: dark text */
   overflow-x: auto;
 }
@@ -729,11 +737,10 @@ html[data-theme="dark"] .doc .listingblock pre.highlight {
 
 .doc pre > code,
 .doc details .listingblock .content pre > code {
-  padding-bottom: 1rem;
   border: none;
   white-space: pre-wrap;
   font-weight: lighter;
-  line-height: 1.7;
+  line-height: 1.5;
 }
 
 .doc blockquote {
@@ -2039,7 +2046,7 @@ pre code[class*=language-] {
 }
 
 pre.code-first-child {
-  padding-bottom: 0 !important;
+  padding-bottom: 16px !important; /* Match .doc pre top padding for symmetric spacing */
 }
 
 html[data-theme=dark] code[class*=language-],
@@ -2100,17 +2107,24 @@ html[data-theme="dark"] .doc .listingblock > .content {
   visibility: hidden;
   position: absolute;
   top: 8px;
-  right: 14px;
+  right: 10px;
   color: var(--grey-500-new, #6b7280); /* Light mode */
   font-family: var(--body-font-family);
   font-size: calc(12 / var(--rem-base) * 1rem);
   line-height: 1.5;
   white-space: nowrap;
   z-index: 1;
+  /* Toolbox floats over the code on hover - backdrop keeps it legible */
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--grey-50-new, #f9fafb);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
 }
 
 html[data-theme="dark"] .doc .source-toolbox {
   color: #a8b2c7;
+  background: #182236;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .doc .listingblock:hover .source-toolbox {

--- a/src/partials/version-selector.hbs
+++ b/src/partials/version-selector.hbs
@@ -4,7 +4,8 @@
   Only renders when component has multiple versions.
 
   Version status logic:
-  - @first in page.versions = Latest (the most recent version)
+  - prerelease = Beta
+  - page.component.latest = Latest (the most recent GA version)
   - is-eol = End of life
   - Otherwise = Supported
 --}}
@@ -12,19 +13,19 @@
   {{#if (ne page.componentVersion.displayVersion 'default')}}
 <div class="sm-ver" data-version-selector>
   <button type="button" class="sm-ver-pill" aria-haspopup="dialog" aria-expanded="false">
-    {{!-- Status dot - determine version status: current (latest), supported, or eol --}}
+    {{!-- Status dot - determine version status: beta (prerelease), current (latest GA), supported, or eol --}}
     {{#each page.versions as |ver|}}
       {{#if (eq ver.version @root.page.version)}}
-    <span class="sm-ver-pill-dot" data-status="{{#if @first}}current{{else if (is-eol ver.asciidoc.attributes)}}eol{{else}}supported{{/if}}" aria-hidden="true"></span>
+    <span class="sm-ver-pill-dot" data-status="{{#if ver.prerelease}}beta{{else if (eq ver.version @root.page.component.latest.version)}}current{{else if (is-eol ver.asciidoc.attributes)}}eol{{else}}supported{{/if}}" aria-hidden="true"></span>
       {{/if}}
     {{/each}}
     <span class="sm-ver-pill-label">Docs for</span>
     <span class="sm-ver-pill-num">v{{page.componentVersion.displayVersion}}</span>
     <span class="sm-ver-pill-sep" aria-hidden="true"></span>
-    {{!-- Status label: Latest (first), End of life (eol), or Supported --}}
+    {{!-- Status label: Beta (prerelease), Latest (latest GA), End of life (eol), or Supported --}}
     {{#each page.versions as |ver|}}
       {{#if (eq ver.version @root.page.version)}}
-    <span class="sm-ver-pill-status" data-status="{{#if @first}}current{{else if (is-eol ver.asciidoc.attributes)}}eol{{else}}supported{{/if}}">{{#if @first}}Latest{{else if (is-eol ver.asciidoc.attributes)}}End of life{{else}}Supported{{/if}}</span>
+    <span class="sm-ver-pill-status" data-status="{{#if ver.prerelease}}beta{{else if (eq ver.version @root.page.component.latest.version)}}current{{else if (is-eol ver.asciidoc.attributes)}}eol{{else}}supported{{/if}}">{{#if ver.prerelease}}Beta{{else if (eq ver.version @root.page.component.latest.version)}}Latest{{else if (is-eol ver.asciidoc.attributes)}}End of life{{else}}Supported{{/if}}</span>
       {{/if}}
     {{/each}}
     <svg class="sm-ver-pill-caret" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -49,7 +50,49 @@
       </div>
     </div>
     <div class="sm-ver-list">
-      {{!-- Current/Latest version group - only the first (latest) version --}}
+      {{!-- Beta/prerelease versions group --}}
+      <div class="sm-ver-group" data-group="beta">
+        <div class="sm-ver-group-head">
+          <span class="sm-ver-group-label">Beta</span>
+          <span class="sm-ver-group-count" data-count="beta">0</span>
+        </div>
+        <div class="sm-ver-rows">
+          {{#each page.versions}}
+          {{#if ./prerelease}}
+          <a class="sm-ver-row{{#if (eq ./version @root.page.version)}} is-selected{{/if}}" data-status="beta" href="{{{relativize ./url}}}">
+            <div class="sm-ver-row-num">
+              <span class="sm-ver-row-v">v{{./displayVersion}}</span>
+              <span class="sm-ver-row-note">Beta</span>
+            </div>
+            {{#if ./asciidoc.attributes.page-release-date}}
+            <div class="sm-ver-row-dates">
+              <span class="sm-ver-row-date">
+                <span class="sm-ver-row-date-l">Released</span>
+                <span class="sm-ver-row-date-v">{{format-release-date ./asciidoc.attributes.page-release-date}}</span>
+              </span>
+              <span class="sm-ver-row-date">
+                <span class="sm-ver-row-date-l">Until</span>
+                <span class="sm-ver-row-date-v">{{#if ./asciidoc.attributes.page-eol-date}}{{{./asciidoc.attributes.page-eol-date}}}{{else}}{{support-end-date ./asciidoc.attributes.page-release-date ./asciidoc.attributes.page-support-months}}{{/if}}</span>
+              </span>
+            </div>
+            {{/if}}
+            <span class="sm-ver-row-status" data-status="beta">
+              <span class="sm-ver-row-status-dot"></span>
+              Beta
+            </span>
+            {{#if (eq ./version @root.page.version)}}
+            <span class="sm-ver-row-check" aria-label="Selected">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4">
+                <polyline points="5 13 9 17 19 7"></polyline>
+              </svg>
+            </span>
+            {{/if}}
+          </a>
+          {{/if}}
+          {{/each}}
+        </div>
+      </div>
+      {{!-- Current/Latest version group - the latest GA (non-prerelease) version --}}
       <div class="sm-ver-group" data-group="current">
         <div class="sm-ver-group-head">
           <span class="sm-ver-group-label">Latest</span>
@@ -57,7 +100,7 @@
         </div>
         <div class="sm-ver-rows">
           {{#each page.versions}}
-          {{#if @first}}
+          {{#if (and (not ./prerelease) (eq ./version @root.page.component.latest.version))}}
           <a class="sm-ver-row{{#if (eq ./version @root.page.version)}} is-selected{{/if}}" data-status="current" href="{{{relativize ./url}}}">
             <div class="sm-ver-row-num">
               <span class="sm-ver-row-v">v{{./displayVersion}}</span>
@@ -99,7 +142,8 @@
         </div>
         <div class="sm-ver-rows">
           {{#each page.versions}}
-          {{#unless @first}}
+          {{#unless ./prerelease}}
+          {{#unless (eq ./version @root.page.component.latest.version)}}
           {{#unless (is-eol ./asciidoc.attributes)}}
           <a class="sm-ver-row{{#if (eq ./version @root.page.version)}} is-selected{{/if}}" data-status="supported" href="{{{relativize ./url}}}">
             <div class="sm-ver-row-num">
@@ -131,6 +175,7 @@
           </a>
           {{/unless}}
           {{/unless}}
+          {{/unless}}
           {{/each}}
         </div>
       </div>
@@ -142,7 +187,7 @@
         </div>
         <div class="sm-ver-rows">
           {{#each page.versions}}
-          {{#unless @first}}
+          {{#unless ./prerelease}}
           {{#if (is-eol ./asciidoc.attributes)}}
           <a class="sm-ver-row{{#if (eq ./version @root.page.version)}} is-selected{{/if}}" data-status="eol" href="{{{relativize ./url}}}">
             <div class="sm-ver-row-num">
@@ -197,12 +242,8 @@
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M7 17l9.2-9.2M17 17V7H7"/></svg>
         Upgrade guide
       </a>
-      {{!-- Support policy link from extension config (page-eol-doc) --}}
-      {{#if page.attributes.eol-doc}}
-      <a class="sm-ver-foot-link" href="{{page.attributes.eol-doc}}" target="_blank" rel="noopener">
-      {{else}}
-      <a class="sm-ver-foot-link" href="https://docs.redpanda.com/current/reference/versions/" target="_blank" rel="noopener">
-      {{/if}}
+      {{!-- Support policy link - Enterprise Support Services and Policies article --}}
+      <a class="sm-ver-foot-link" href="https://support.redpanda.com/hc/en-us/articles/20682204531351-Enterprise-Support-Services-and-Policies" target="_blank" rel="noopener">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12h6M12 9v6M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
         Support policy
       </a>


### PR DESCRIPTION
Fixes three issues reported on streaming docs pages (e.g. the [streaming/26.2 stretch-clusters preview](https://deploy-preview-1681--redpanda-docs-preview.netlify.app/streaming/26.2/deploy/redpanda/kubernetes/k-stretch-clusters/)).

## 1. Support policy link
The version selector's "Support policy" footer link fell back to `https://docs.redpanda.com/current/reference/versions/`. It now always points to the correct **Enterprise Support Services and Policies** article: `https://support.redpanda.com/hc/en-us/articles/20682204531351-Enterprise-Support-Services-and-Policies`.

## 2. Beta/prerelease version mislabeled "Latest"
When the current version is an Antora prerelease (e.g. 26.2 Beta), the pill, group, and rows all read "Latest".

- Prerelease versions are now labeled **"Beta"** in a dedicated Beta group (violet styling, distinct from green Latest/Supported and amber EOL).
- The latest GA version (`page.component.latest`) is promoted into the **Latest** group.
- Detection uses the Antora `prerelease` flag and `page.component.latest`, matching the existing logic in `latest-banner.hbs`. Non-prerelease components are unaffected (the Beta group is empty and auto-hidden).

## 3. Inconsistent code-block styling
Confirmed via computed styles + light/dark screenshots:

- **Inner border** — `base.css` puts a border on every `pre`/`code`, which showed inside the `.content` frame (visible in dark mode). Removed from block `pre`.
- **Loose/uneven line spacing** ("big gaps") — `pre` was 1.65 and inner `code` was 1.7; unified to **1.5**.
- **Asymmetric padding** — `pre` reserved 40px of top space for the hover toolbar (plus a `code` `padding-bottom`), leaving short blocks top-heavy. Now uses symmetric **16px** top/bottom; the toolbar floats over the top-right on hover with a small backdrop for legibility.

Mirrored in `doc-bump.css` so the search/Ask-AI overlay code blocks match.

## Testing
- Verified locally with `gulp preview` in both light and dark themes: Beta group + violet styling, GA promoted to Latest, correct support link, and code blocks with no inner border, tight even spacing, balanced padding, and a legible floating toolbar.
- `preview-src/ui-model.yml` gains a prerelease streaming version so the Beta path is exercisable in local preview.
- `gulp lint` passes.