### PR TITLE
Add support disclaimer to Preview badge tooltip

### DIFF
--- a/preview-src/preview-status-test.adoc
+++ b/preview-src/preview-status-test.adoc
@@ -13,4 +13,4 @@ This page demonstrates the **Preview** status badge.
 
 Hover the Preview pill. Default text:
 
-_"This feature is in preview and may change."_
+_"This feature is in preview and may change. Features in preview are not covered by Enterprise Support, SLAs, or the standard Redpanda Support process."_

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -29,7 +29,7 @@
     <span class="status-badge status-badge--beta" data-tippy-content="{{#if page.attributes.beta-text}}{{page.attributes.beta-text}}{{else}}This feature is in beta and may change.{{/if}}">beta</span>
     {{/if}}
     {{#if page.attributes.preview}}
-    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change. Features in preview are not supported by Redpanda.{{/if}}">Preview</span>
+    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change. Features in preview are not subject to Enterprise Support, SLAs, or the standard Redpanda support process.{{/if}}">Preview</span>
     {{/if}}
     {{#if page.attributes.limited-availability}}
     <span class="status-badge status-badge--la" {{#if page.attributes.limited-availability-text}}data-tippy-content="{{page.attributes.limited-availability-text}}"{{/if}}>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -29,7 +29,7 @@
     <span class="status-badge status-badge--beta" data-tippy-content="{{#if page.attributes.beta-text}}{{page.attributes.beta-text}}{{else}}This feature is in beta and may change.{{/if}}">beta</span>
     {{/if}}
     {{#if page.attributes.preview}}
-    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change. Features in preview are not covered by Enterprise Support, SLAs, or the standard Redpanda support process.{{/if}}">Preview</span>
+    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change. Features in preview are not covered by Enterprise Support, SLAs, or the standard Redpanda Support process.{{/if}}">Preview</span>
     {{/if}}
     {{#if page.attributes.limited-availability}}
     <span class="status-badge status-badge--la" {{#if page.attributes.limited-availability-text}}data-tippy-content="{{page.attributes.limited-availability-text}}"{{/if}}>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -29,7 +29,7 @@
     <span class="status-badge status-badge--beta" data-tippy-content="{{#if page.attributes.beta-text}}{{page.attributes.beta-text}}{{else}}This feature is in beta and may change.{{/if}}">beta</span>
     {{/if}}
     {{#if page.attributes.preview}}
-    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change.{{/if}}">Preview</span>
+    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change. Features in preview are not supported by Redpanda.{{/if}}">Preview</span>
     {{/if}}
     {{#if page.attributes.limited-availability}}
     <span class="status-badge status-badge--la" {{#if page.attributes.limited-availability-text}}data-tippy-content="{{page.attributes.limited-availability-text}}"{{/if}}>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -29,7 +29,7 @@
     <span class="status-badge status-badge--beta" data-tippy-content="{{#if page.attributes.beta-text}}{{page.attributes.beta-text}}{{else}}This feature is in beta and may change.{{/if}}">beta</span>
     {{/if}}
     {{#if page.attributes.preview}}
-    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change. Features in preview are not subject to Enterprise Support, SLAs, or the standard Redpanda support process.{{/if}}">Preview</span>
+    <span class="status-badge status-badge--preview" data-tippy-content="{{#if page.attributes.preview-text}}{{page.attributes.preview-text}}{{else}}This feature is in preview and may change. Features in preview are not covered by Enterprise Support, SLAs, or the standard Redpanda support process.{{/if}}">Preview</span>
     {{/if}}
     {{#if page.attributes.limited-availability}}
     <span class="status-badge status-badge--la" {{#if page.attributes.limited-availability-text}}data-tippy-content="{{page.attributes.limited-availability-text}}"{{/if}}>


### PR DESCRIPTION
## What

Updates the default Preview badge tooltip text to add a support disclaimer.

**Before:** "This feature is in preview and may change."
**After:** "This feature is in preview and may change. Features in preview are not covered by Enterprise Support, SLAs, or the standard Redpanda Support process."

## Where

- `src/partials/article.hbs` — the `{{else}}` fallback for the Preview status badge. Per-page `preview-text` overrides are unaffected.
- `preview-src/preview-status-test.adoc` — badge test fixture updated to match the new default text.

## Notes

- Site-wide change: affects the Preview badge on every page across docs.redpanda.com, not just Agentic Data Plane pages.
- beta and Limited Availability tooltips are unchanged.
- Requires a docs-ui version bump + release for consuming repos to pick it up (not included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)