### PR TITLE
Lead-gen Group 4: first-party docs-behavior beacon (capture only)

### DIFF
--- a/src/js/27-docs-activity.js
+++ b/src/js/27-docs-activity.js
@@ -1,0 +1,50 @@
+/* global sessionStorage, fetch */
+/**
+ * First-party docs-behavior beacon (lead capture).
+ *
+ * For SIGNED-IN docs users only (rp_docs_auth hint cookie), reports one
+ * pageview per navigation to the docs-site /docs-activity endpoint, which
+ * records it server-side against the user's account. Replaces anonymous
+ * third-party analytics (Plausible/Heap/Algolia) for lead purposes.
+ *
+ * Anonymous visitors send nothing. Same-origin, so the session cookie rides
+ * along automatically. Fire-and-forget; never blocks or throws into the page.
+ */
+;(function () {
+  'use strict'
+
+  // Only signed-in users are tracked (matches 26-docs-account.js).
+  if (!/(?:^|;\s*)rp_docs_auth=1(?:;|$)/.test(document.cookie)) return
+
+  var path = window.location.pathname
+  if (!path) return
+
+  // Beacon once per path per tab session — avoids duplicate writes on
+  // back/forward and re-renders. Keeps server write volume to real navigations.
+  try {
+    var key = 'docs-activity-seen'
+    var seen = (sessionStorage.getItem(key) || '').split('\n')
+    if (seen.indexOf(path) !== -1) return
+    seen.push(path)
+    sessionStorage.setItem(key, seen.slice(-200).join('\n'))
+  } catch (e) { /* private mode: proceed without dedupe */ }
+
+  // Antora component (product) exposed by the layout: <body data-component=…>
+  var component = (document.body && document.body.getAttribute('data-component')) || null
+
+  // Capture the search term on the standalone /search page (URL-driven).
+  var q = null
+  if (path.indexOf('/search') !== -1) {
+    try { q = new URLSearchParams(window.location.search).get('q') } catch (e) { /* ignore */ }
+  }
+
+  try {
+    fetch('/docs-activity', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: path, component: component, q: q }),
+      keepalive: true,
+    }).catch(function () { /* best-effort */ })
+  } catch (e) { /* never break the page */ }
+})()


### PR DESCRIPTION
**Draft / WIP — capture only.** The docs-ui half of Group 4 in the lead-gen plan. Pairs with the docs-site `/docs-activity` endpoint (docs-site PR #192).

Adds `src/js/27-docs-activity.js`: a signed-in-only pageview beacon. For users with the `rp_docs_auth` hint cookie, it reports one pageview per navigation (path, Antora `data-component`, and the `q` term on `/search`) to the same-origin `/docs-activity` endpoint, which records it server-side against the user's account.

- **Anonymous visitors send nothing.**
- Same-origin, so the session cookie rides along (no CORS).
- Deduped once-per-path-per-tab-session to keep write volume to real navigations.
- Fire-and-forget; never blocks or throws into the page.
- Feeds product area, recent + most-visited pages, get-started (onboarding-intent) visits, and search terms — replacing anonymous Plausible/Heap/Algolia for lead purposes.

Capture only; nothing is delivered to sales (held pending legal confirm). Lint passes. Needs the docs-site endpoint deployed to do anything, and ships in the UI bundle like other JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
