### PR TITLE
Fix connector license notice disappearing and support server-rendered metadata

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -89,7 +89,8 @@ html {
 .component-indicator-sticky {
   display: flex;
   align-items: center;
-  gap: 12px;
+  flex-wrap: wrap;
+  gap: 8px 12px;
   position: sticky;
   top: var(--body-top, 100px);
   z-index: 50;
@@ -301,6 +302,12 @@ html[data-theme="dark"] .component-indicator-sticky .context-dropdown-item:focus
     justify-content: flex-start;
   }
 
+  /* Metadata is left-aligned on mobile, so anchor dropdown menus left to keep them on screen */
+  .component-indicator-sticky .context-dropdown-menu {
+    right: auto;
+    left: 0;
+  }
+
   html[data-theme="dark"] .component-indicator-sticky .metadata-inline {
     border-top-color: rgba(255, 255, 255, 0.06);
   }
@@ -510,6 +517,66 @@ html[data-theme="dark"] .status-badge--cloud {
   background: rgba(14, 165, 233, 0.15);
   color: #7dd3fc;
   border-color: rgba(14, 165, 233, 0.3);
+}
+
+/* Availability badges: links to the other platform's version of this page */
+a.status-badge--cloud-link,
+a.status-badge--self-managed-link {
+  text-decoration: none;
+}
+
+.status-badge--cloud-link {
+  background: #e0f2fe;
+  color: #0369a1;
+  border: 1px solid #7dd3fc;
+}
+
+.status-badge--cloud-link:hover {
+  background: #bae6fd;
+  color: #075985;
+}
+
+.status-badge--self-managed-link {
+  background: #dcfce7;
+  color: #15803d;
+  border: 1px solid #86efac;
+}
+
+.status-badge--self-managed-link:hover {
+  background: #bbf7d0;
+  color: #166534;
+}
+
+.status-badge--self-managed-only {
+  background: var(--grey-100-new, #f3f4f6);
+  color: #4b5563;
+  border: 1px solid var(--grey-200-new, #e5e5e5);
+}
+
+html[data-theme="dark"] .status-badge--cloud-link {
+  background: rgba(14, 165, 233, 0.15);
+  color: #7dd3fc;
+  border-color: rgba(14, 165, 233, 0.3);
+}
+
+html[data-theme="dark"] .status-badge--cloud-link:hover {
+  background: rgba(14, 165, 233, 0.25);
+}
+
+html[data-theme="dark"] .status-badge--self-managed-link {
+  background: rgba(34, 197, 94, 0.15);
+  color: #86efac;
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+html[data-theme="dark"] .status-badge--self-managed-link:hover {
+  background: rgba(34, 197, 94, 0.25);
+}
+
+html[data-theme="dark"] .status-badge--self-managed-only {
+  background: rgba(148, 163, 184, 0.12);
+  color: #cbd5e1;
+  border-color: rgba(148, 163, 184, 0.25);
 }
 
 @media screen and (min-width: 600px) {

--- a/src/helpers/resolve-resource.js
+++ b/src/helpers/resolve-resource.js
@@ -57,6 +57,12 @@ module.exports = (resource, { data, hash: context }) => {
     return resource
   }
 
+  // Root-relative URLs pass through (e.g. pub.url values set by extensions such as
+  // the component_type_dropdown macro's page-context-switcher attribute)
+  if (resource.startsWith('/')) {
+    return resource
+  }
+
   // Handle special keyword "current" - not a valid resource ID
   // This is sometimes incorrectly used to mean "current page" or "current version"
   if (resource === 'current') {

--- a/src/js/24-move-connector-metadata.js
+++ b/src/js/24-move-connector-metadata.js
@@ -18,6 +18,10 @@
     const metadataInline = document.createElement('div')
     metadataInline.className = 'metadata-inline'
 
+    // Elements whose content now lives in the sticky bar, to hide in place.
+    // Anything else in the metadata block (e.g. license requirements) must stay visible.
+    const movedElements = []
+
     // Move the Type dropdown if it exists
     const typeDropdownWrapper = metadataContent.querySelector('.dropdown-wrapper')
     if (typeDropdownWrapper) {
@@ -116,6 +120,7 @@
         contextDropdown.appendChild(compactMenu)
         contextSwitcher.appendChild(contextDropdown)
         metadataInline.appendChild(contextSwitcher)
+        movedElements.push(typeDropdownWrapper)
       }
     }
 
@@ -264,6 +269,7 @@
         availabilityDropdown.appendChild(dropdownButton)
         availabilityDropdown.appendChild(dropdownMenu)
         metadataInline.appendChild(availabilityDropdown)
+        movedElements.push(availabilityPara)
       }
     }
 
@@ -277,8 +283,19 @@
         stickyBar.appendChild(metadataInline)
       }
 
-      // Hide the original metadata block
-      metadataBlock.style.display = 'none'
+      // Hide only the elements now represented in the sticky bar
+      movedElements.forEach((el) => {
+        el.style.display = 'none'
+      })
+
+      // Hide the whole block only if nothing meaningful remains
+      // (license requirements and other notices must stay visible)
+      const hasRemainingContent = Array.from(metadataContent.children).some(
+        (el) => el.style.display !== 'none' && el.textContent.trim() !== ''
+      )
+      if (!hasRemainingContent) {
+        metadataBlock.style.display = 'none'
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

On Redpanda Connect connector pages, the enterprise license notice flashed on page load and then disappeared ([DOC-2383](https://redpandadata.atlassian.net/browse/DOC-2383)). `24-move-connector-metadata.js` moves the Type dropdown and availability info into the sticky bar, then hides the **entire** `.metadata-block` - including the license notice it never moved. This affects all enterprise connectors (reported via the docs feedback form for `postgres_cdc`).

## Changes

- **`src/js/24-move-connector-metadata.js`**: hide only the elements actually moved into the sticky bar (Type dropdown wrapper and the "Available in:" paragraph). The whole block is hidden only when nothing meaningful remains, so the license notice stays visible in the body.
- **`src/helpers/resolve-resource.js`**: pass root-relative URLs (`/connect/...`) through unchanged. The companion change in docs-extensions-and-macros (redpanda-data/docs-extensions-and-macros#216) sets `page-context-switcher` with `pub.url` values, which are not resolvable resource IDs; without this the context-switcher partial logs an unresolved-resource warning per link.

## Why this happens on every connector page

The macro in docs-extensions-and-macros already tried to set the sticky-bar page attributes that `article.hbs` renders server-side, but attributes set by Asciidoctor extensions can never reach UI templates: Antora extracts page attributes in a header-only parse with extensions disabled, and `convertDocument` only re-extracts metadata when `page.asciidoc` is unset (it never is). So every connector page falls back to the client-side script. The companion PR moves the attribute-setting to the `documentsConverted` event, which makes the sticky bar render at build time with no flash. This PR's script fix then acts as a safety net for content built with older extension versions.

## Testing

- Reproduced the full pipeline in an isolated Antora build (real extension + macro + this UI bundle): sticky-bar metadata renders server-side, license notice stays visible, availability badges and context switcher correct for self-managed, cloud, and self-managed-only connectors.
- Verified the script fix in a browser harness against live `postgres_cdc` markup: license paragraph stays visible, availability paragraph hidden, sticky bar populated; non-enterprise pages unchanged.
- `gulp lint` passes.

## Rollout

Release this first (fixes the disappearing license immediately), then release the extensions change and rebuild the docs to eliminate the flash entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2383]: https://redpandadata.atlassian.net/browse/DOC-2383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ