### PR TITLE
Fix stacked modals on Mermaid diagrams and squished figure captions

### DIFF
--- a/src/css/mermaid.css
+++ b/src/css/mermaid.css
@@ -4,6 +4,12 @@
   text-align: center;
 }
 
+/* Mermaid SVGs have no internal bottom padding, so the figure caption
+   needs more separation than a regular image caption. */
+.doc .imageblock .mermaid + .title {
+  margin-top: 1.25rem;
+}
+
 .mermaid > svg {
   background-color: var(--body-background) !important;
   max-width: 100%;

--- a/src/js/07-expand-images.js
+++ b/src/js/07-expand-images.js
@@ -18,6 +18,9 @@
   if (!blocks.length || !modalOverlay) return
 
   blocks.forEach((block) => {
+    // Mermaid diagrams have their own zoom modal (20-mermaid-zoom.js).
+    // Binding both opens two stacked modals for one click.
+    if (block.querySelector('.mermaid')) return
     block.addEventListener('click', function (e) {
       const media = block.querySelector('img, svg')
       if (!media) return

--- a/src/js/08-mermaid-label-spacing.js
+++ b/src/js/08-mermaid-label-spacing.js
@@ -1,0 +1,77 @@
+;(function () {
+  'use strict'
+
+  // Mermaid (v10 and v11) never reserves vertical space between a subgraph
+  // label and nested subgraphs: the label overlaps the inner boxes' top
+  // borders, and neither flowchart.subGraphTitleMargin nor flowchart.padding
+  // moves the children. Fix the rendered SVG instead: shift the label up and
+  // grow the cluster rect (and the viewBox for top-level clusters) to match.
+
+  const MIN_GAP = 12
+
+  if (!document.querySelector('.mermaid')) return
+
+  function fixSvg (svg) {
+    const clusters = Array.from(svg.querySelectorAll('g.cluster'))
+    let viewBoxGrow = 0
+    clusters.forEach(function (cluster) {
+      const rect = cluster.querySelector('rect')
+      const label = cluster.querySelector('.cluster-label')
+      if (!rect || !label) return
+      const rx = parseFloat(rect.getAttribute('x'))
+      const ry = parseFloat(rect.getAttribute('y'))
+      const rw = parseFloat(rect.getAttribute('width'))
+      const rh = parseFloat(rect.getAttribute('height'))
+      const m = (label.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]\s*([-\d.]+)\s*\)/)
+      if (!m) return
+      const lx = parseFloat(m[1])
+      const ly = parseFloat(m[2])
+      let lh
+      try {
+        lh = label.getBBox().height
+      } catch (e) {
+        return // not rendered (display: none); leave untouched
+      }
+      // Find the highest cluster rect fully contained in this one
+      let minChildTop = Infinity
+      clusters.forEach(function (other) {
+        if (other === cluster) return
+        const or = other.querySelector('rect')
+        if (!or) return
+        const ox = parseFloat(or.getAttribute('x'))
+        const oy = parseFloat(or.getAttribute('y'))
+        const ow = parseFloat(or.getAttribute('width'))
+        const oh = parseFloat(or.getAttribute('height'))
+        const contained = ox >= rx - 1 && ox + ow <= rx + rw + 1 && oy > ry && oy + oh <= ry + rh + 1
+        if (contained && oy < minChildTop) minChildTop = oy
+      })
+      if (minChildTop === Infinity) return
+      const gap = minChildTop - (ly + lh)
+      if (gap >= MIN_GAP) return
+      const delta = Math.ceil(MIN_GAP - gap)
+      label.setAttribute('transform', 'translate(' + lx + ', ' + (ly - delta) + ')')
+      rect.setAttribute('y', ry - delta)
+      rect.setAttribute('height', rh + delta)
+      viewBoxGrow = Math.max(viewBoxGrow, delta)
+    })
+    if (viewBoxGrow > 0) {
+      const vb = (svg.getAttribute('viewBox') || '').split(/[ ,]+/).map(Number)
+      if (vb.length === 4 && vb.every(function (n) { return !isNaN(n) })) {
+        vb[1] -= viewBoxGrow
+        vb[3] += viewBoxGrow
+        svg.setAttribute('viewBox', vb.join(' '))
+      }
+    }
+    svg.setAttribute('data-label-spacing', 'fixed')
+  }
+
+  // Mermaid renders asynchronously after its module loads; poll briefly.
+  let attempts = 0
+  const timer = setInterval(function () {
+    attempts++
+    const pending = document.querySelectorAll('.mermaid svg:not([data-label-spacing])')
+    pending.forEach(fixSvg)
+    const remaining = document.querySelectorAll('.mermaid:not([data-processed])').length
+    if (remaining === 0 || attempts > 100) clearInterval(timer)
+  }, 200)
+})()

--- a/src/js/08-mermaid-label-spacing.js
+++ b/src/js/08-mermaid-label-spacing.js
@@ -12,15 +12,35 @@
   if (!document.querySelector('.mermaid')) return
 
   function fixSvg (svg) {
+    // Hidden diagrams (e.g. in an inactive context-switcher tab) have no
+    // layout: getBBox() throws in Firefox and returns zero-height boxes in
+    // Chrome. Leave them unstamped so a later pass can fix them once revealed.
+    if (svg.getClientRects().length === 0) return
+
     const clusters = Array.from(svg.querySelectorAll('g.cluster'))
+
+    function contains (outer, inner) {
+      const ox = parseFloat(outer.getAttribute('x'))
+      const oy = parseFloat(outer.getAttribute('y'))
+      const ow = parseFloat(outer.getAttribute('width'))
+      const oh = parseFloat(outer.getAttribute('height'))
+      const ix = parseFloat(inner.getAttribute('x'))
+      const iy = parseFloat(inner.getAttribute('y'))
+      const iw = parseFloat(inner.getAttribute('width'))
+      const ih = parseFloat(inner.getAttribute('height'))
+      return ix >= ox - 1 && ix + iw <= ox + ow + 1 && iy > oy && iy + ih <= oy + oh + 1
+    }
+
+    // Clusters are processed in document order and measured live, so a
+    // cluster shifted early feeds its new position to clusters measured
+    // later. The one-directional (upward) shifts keep that stable enough
+    // in practice; don't rely on exact pixel positions across siblings.
     let viewBoxGrow = 0
     clusters.forEach(function (cluster) {
       const rect = cluster.querySelector('rect')
       const label = cluster.querySelector('.cluster-label')
       if (!rect || !label) return
-      const rx = parseFloat(rect.getAttribute('x'))
       const ry = parseFloat(rect.getAttribute('y'))
-      const rw = parseFloat(rect.getAttribute('width'))
       const rh = parseFloat(rect.getAttribute('height'))
       const m = (label.getAttribute('transform') || '').match(/translate\(\s*([-\d.]+)[ ,]\s*([-\d.]+)\s*\)/)
       if (!m) return
@@ -38,21 +58,25 @@
         if (other === cluster) return
         const or = other.querySelector('rect')
         if (!or) return
-        const ox = parseFloat(or.getAttribute('x'))
         const oy = parseFloat(or.getAttribute('y'))
-        const ow = parseFloat(or.getAttribute('width'))
-        const oh = parseFloat(or.getAttribute('height'))
-        const contained = ox >= rx - 1 && ox + ow <= rx + rw + 1 && oy > ry && oy + oh <= ry + rh + 1
-        if (contained && oy < minChildTop) minChildTop = oy
+        if (contains(rect, or) && oy < minChildTop) minChildTop = oy
       })
       if (minChildTop === Infinity) return
       const gap = minChildTop - (ly + lh)
       if (gap >= MIN_GAP) return
       const delta = Math.ceil(MIN_GAP - gap)
+      // Only top-level clusters push against the viewBox; a shift on a
+      // nested cluster is absorbed inside its parent. Decide before the
+      // shift moves this rect relative to its parent.
+      const isNested = clusters.some(function (other) {
+        if (other === cluster) return false
+        const or = other.querySelector('rect')
+        return or && contains(or, rect)
+      })
       label.setAttribute('transform', 'translate(' + lx + ', ' + (ly - delta) + ')')
       rect.setAttribute('y', ry - delta)
       rect.setAttribute('height', rh + delta)
-      viewBoxGrow = Math.max(viewBoxGrow, delta)
+      if (!isNested) viewBoxGrow = Math.max(viewBoxGrow, delta)
     })
     if (viewBoxGrow > 0) {
       const vb = (svg.getAttribute('viewBox') || '').split(/[ ,]+/).map(Number)
@@ -65,13 +89,24 @@
     svg.setAttribute('data-label-spacing', 'fixed')
   }
 
+  function fixPending () {
+    document.querySelectorAll('.mermaid svg:not([data-label-spacing])').forEach(fixSvg)
+  }
+
   // Mermaid renders asynchronously after its module loads; poll briefly.
   let attempts = 0
   const timer = setInterval(function () {
     attempts++
-    const pending = document.querySelectorAll('.mermaid svg:not([data-label-spacing])')
-    pending.forEach(fixSvg)
+    fixPending()
     const remaining = document.querySelectorAll('.mermaid:not([data-processed])').length
-    if (remaining === 0 || attempts > 100) clearInterval(timer)
+    if (remaining === 0 || attempts > 100) {
+      clearInterval(timer)
+      // Diagrams hidden while the poll ran (e.g. in inactive tabs) are left
+      // unstamped; retry after clicks, which is how tabs get revealed. The
+      // selector is empty once everything is fixed, so this stays cheap.
+      if (document.querySelector('.mermaid svg:not([data-label-spacing])')) {
+        document.addEventListener('click', function () { setTimeout(fixPending, 50) })
+      }
+    }
   }, 200)
 })()

--- a/src/partials/feedback-forms.hbs
+++ b/src/partials/feedback-forms.hbs
@@ -43,6 +43,4 @@
       </div>
     </div>
   </div>
-
-  <div class="modal-overlay" id="modal-overlay"></div>
 </form>


### PR DESCRIPTION
## Problems

1. **Two stacked modals per click.** The Antora Mermaid extension wraps every diagram in `<div class="imageblock">`, so `07-expand-images.js` bound its generic lightbox to Mermaid diagrams in addition to the dedicated zoom modal from `20-mermaid-zoom.js`. One click opened both overlays (Mermaid modal at `z-index: 2147483647`, generic at `9999`). Closing the Mermaid modal revealed the generic lightbox underneath: a dimmed page showing through the cloned transparent-background SVG, with a stray close button in the corner.
2. **Squished captions.** Mermaid SVGs have no internal bottom padding, so the standard `0.5rem` figure-caption margin left the caption pressed against the diagram's bottom boxes.
3. **Duplicate `#modal-overlay`.** `feedback-forms.hbs` shipped an empty `<div class="modal-overlay" id="modal-overlay">` that nothing references. It duplicates the id of the expand-images overlay, so `getElementById('modal-overlay')` returns the dead element.

## Fixes

- `07-expand-images.js`: skip imageblocks that contain a `.mermaid` diagram when binding the generic lightbox
- `mermaid.css`: `1.25rem` top margin for figure captions that follow a Mermaid diagram
- `feedback-forms.hbs`: remove the dead duplicate overlay div

## Second commit: subgraph label spacing

Mermaid v10 and v11 flowcharts never reserve vertical space between a subgraph label and nested subgraphs: the label overlaps the inner boxes' top borders, and no configuration changes this (`flowchart.subGraphTitleMargin.bottom` only grows the box downward, `.top` pushes the label down into the content, and `flowchart.padding` is a no-op for label-to-child distance; all measured at a constant -3px gap). A new `08-mermaid-label-spacing.js` post-processes each rendered SVG: for any cluster whose label sits within 12px of a fully-contained child cluster, it shifts the label up, grows the cluster rect, and expands the viewBox for top-level clusters. Verified on the Stretch Cluster topology diagrams (label-to-content gap goes from -2px overlap to +8px clear space), with side-by-side and stacked sibling panels correctly left untouched.

## Verification

Reproduced both bugs on the live deploy-preview for redpanda-data/docs#1820 (Chrome DevTools protocol: real click opened both overlays; closing the Mermaid modal left `.modal-overlay.active` behind). Rebuilt the bundle with these fixes, built the docs site against it, and re-ran the same click sequence: only the Mermaid modal opens, closing it restores the page with no lingering overlay and body scroll intact, and the caption spacing renders with clear separation. `gulp lint` and `gulp bundle` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
