### PR TITLE
Style inline badges from the badge macro

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -2830,3 +2830,56 @@ html[data-theme="dark"] .availability-selector-menu {
 html[data-theme="dark"] .availability-selector-item:hover {
   background: rgba(255, 255, 255, 0.06);
 }
+
+/* Inline badges from the badge macro (badge::[label=...]).
+   Distinct from .status-badge, the page-level beta pill. */
+.doc .badge {
+  display: inline-block;
+  padding: 0 0.4em;
+  border-radius: 9999px;
+  font-size: 0.75em;
+  font-weight: 600;
+  vertical-align: baseline;
+  white-space: nowrap;
+}
+
+.doc .badge--beta {
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+}
+
+.doc .badge--deprecated {
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fca5a5;
+}
+
+.doc .badge--enterprise {
+  background: #ede9fe;
+  color: #5b21b6;
+  border: 1px solid #c4b5fd;
+}
+
+.doc .badge--large {
+  font-size: 0.9em;
+  padding: 0.15em 0.6em;
+}
+
+html[data-theme="dark"] .doc .badge--beta {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fcd34d;
+  border-color: rgba(251, 191, 36, 0.3);
+}
+
+html[data-theme="dark"] .doc .badge--deprecated {
+  background: rgba(248, 113, 113, 0.15);
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.3);
+}
+
+html[data-theme="dark"] .doc .badge--enterprise {
+  background: rgba(167, 139, 250, 0.15);
+  color: #c4b5fd;
+  border-color: rgba(167, 139, 250, 0.3);
+}


### PR DESCRIPTION
The shared `badge` inline macro (`badge::[label=...]`) emits `.badge.badge--<label>` spans, but docs-ui only styles `.status-badge` (the page-level beta pill), so inline badges render as unstyled plain text. This became visible when redpanda-data/docs#1808 registered the macro in the streaming playbook and used `badge::[label=beta]` for section-level beta markers (per team convention: page-level beta uses `:page-beta:`, section-level uses the badge macro).

Adds styling for the three standard labels (beta, deprecated, enterprise) plus the `size=large` variant, with dark-theme colors mirroring the existing status-badge palette. Graceful before/after: without this, badges read as plain "(beta)" text; with it, they render as small pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)