### PR TITLE
feat(page-actions): add agent handoff prompt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/src/js/13-agent-handoff.js @redpanda-data/documentation

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+      - name: Test page actions
+        run: npm run test:markdown-dropdown
       - name: Cache generated files
         uses: actions/cache@v4
         with:

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "scripts": {
+    "test:markdown-dropdown": "node --test tests/markdown-dropdown/*.test.js",
     "test:headless": "node tests/bloblang-playground/test-runner.js",
     "test:playground": "npm run build:wasm && npm run test:headless",
     "test:interactive": "node tests/bloblang-interactive/test-runner.js",

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -6,6 +6,7 @@
 :!table-caption:
 :page-pagination:
 :page-has-markdown:
+:page-agent-handoff:
 
 {description}
 

--- a/src/helpers/has-agent-handoff.js
+++ b/src/helpers/has-agent-handoff.js
@@ -1,0 +1,7 @@
+/**
+ * Show the agent handoff action only when the page opts in.
+ */
+
+module.exports = ({ data: { root } }) => {
+  return root.page?.attributes?.['agent-handoff'] !== undefined
+}

--- a/src/js/13-agent-handoff.js
+++ b/src/js/13-agent-handoff.js
@@ -8,45 +8,65 @@
   }
 })(typeof window === 'undefined' ? this : window, function () {
   const headingPattern = /^(#{1,6})[ \t]+(.+?)\s*$/
-  const componentExportPattern =
-    /Component-specific:[^\n]*\]\((https?:\/\/[^)\s]+-full\.txt)\)/
+  const fencePattern = /^[ \t]*(`{3,}|~{3,})/
 
-  function normalizedAnchor (sectionAnchor) {
+  function normalizedAnchors (sectionAnchor) {
     const rawAnchor = sectionAnchor.replace(/^#/, '')
+    let decodedAnchor
 
     try {
-      return decodeURIComponent(rawAnchor)
+      decodedAnchor = decodeURIComponent(rawAnchor)
     } catch (error) {
-      return rawAnchor
+      decodedAnchor = rawAnchor
     }
+
+    const generatedMarkdownAnchor = decodedAnchor.replace(/^_/, '').replace(/_/g, '-')
+    return generatedMarkdownAnchor === decodedAnchor
+      ? [decodedAnchor]
+      : [decodedAnchor, generatedMarkdownAnchor]
   }
 
   function extractMarkdownSection (markdown, sectionAnchor) {
     const fullPage = markdown.trim()
     if (!sectionAnchor) return fullPage
 
-    const anchorMarker = `(#${normalizedAnchor(sectionAnchor)})`
+    const anchorMarkers = normalizedAnchors(sectionAnchor).map((anchor) => `(#${anchor})`)
     const lines = fullPage.split('\n')
-    const startIndex = lines.findIndex((line) => headingPattern.test(line) && line.includes(anchorMarker))
+    const headingLines = computeHeadingLines(lines)
+    const startIndex = lines.findIndex(
+      (line, index) => headingLines[index] && anchorMarkers.some((marker) => line.includes(marker))
+    )
     if (startIndex === -1) return fullPage
 
     const sectionLevel = lines[startIndex].match(headingPattern)[1].length
     const endIndex = lines.findIndex((line, index) => {
       if (index <= startIndex) return false
 
-      const heading = line.match(headingPattern)
-      return heading && heading[1].length <= sectionLevel
+      if (!headingLines[index]) return false
+      return line.match(headingPattern)[1].length <= sectionLevel
     })
 
     return lines.slice(startIndex, endIndex === -1 ? undefined : endIndex).join('\n').trim()
   }
 
-  function componentExportUrl (markdown) {
-    const match = markdown.match(componentExportPattern)
-    return match && match[1]
+  function computeHeadingLines (lines) {
+    let fenceMarker = ''
+
+    return lines.map((line) => {
+      const fence = line.match(fencePattern)
+      if (fence) {
+        const marker = fence[1][0]
+        if (!fenceMarker) fenceMarker = marker
+        else if (marker === fenceMarker) fenceMarker = ''
+        return false
+      }
+
+      return !fenceMarker && headingPattern.test(line)
+    })
   }
 
   function buildAgentHandoffPrompt ({
+    componentName = '',
     docsOrigin,
     markdown,
     markdownUrl,
@@ -56,7 +76,9 @@
     sectionTitle = '',
   }) {
     const context = extractMarkdownSection(markdown, sectionAnchor)
-    const componentExport = componentExportUrl(markdown)
+    const componentExport = componentName
+      ? new URL(`/${encodeURIComponent(componentName)}-full.txt`, docsOrigin).href
+      : null
     const scope = [
       `- Documentation page: ${pageTitle}`,
       sectionTitle ? `- Current section: ${sectionTitle}` : null,

--- a/src/js/13-agent-handoff.js
+++ b/src/js/13-agent-handoff.js
@@ -1,0 +1,108 @@
+;(function (root, factory) {
+  const agentHandoff = factory()
+
+  if (typeof module === 'object' && module.exports) {
+    module.exports = agentHandoff
+  } else {
+    root.RedpandaDocsAgentHandoff = agentHandoff
+  }
+})(typeof window === 'undefined' ? this : window, function () {
+  const headingPattern = /^(#{1,6})[ \t]+(.+?)\s*$/
+  const componentExportPattern =
+    /Component-specific:[^\n]*\]\((https?:\/\/[^)\s]+-full\.txt)\)/
+
+  function normalizedAnchor (sectionAnchor) {
+    const rawAnchor = sectionAnchor.replace(/^#/, '')
+
+    try {
+      return decodeURIComponent(rawAnchor)
+    } catch (error) {
+      return rawAnchor
+    }
+  }
+
+  function extractMarkdownSection (markdown, sectionAnchor) {
+    const fullPage = markdown.trim()
+    if (!sectionAnchor) return fullPage
+
+    const anchorMarker = `(#${normalizedAnchor(sectionAnchor)})`
+    const lines = fullPage.split('\n')
+    const startIndex = lines.findIndex((line) => headingPattern.test(line) && line.includes(anchorMarker))
+    if (startIndex === -1) return fullPage
+
+    const sectionLevel = lines[startIndex].match(headingPattern)[1].length
+    const endIndex = lines.findIndex((line, index) => {
+      if (index <= startIndex) return false
+
+      const heading = line.match(headingPattern)
+      return heading && heading[1].length <= sectionLevel
+    })
+
+    return lines.slice(startIndex, endIndex === -1 ? undefined : endIndex).join('\n').trim()
+  }
+
+  function componentExportUrl (markdown) {
+    const match = markdown.match(componentExportPattern)
+    return match && match[1]
+  }
+
+  function buildAgentHandoffPrompt ({
+    docsOrigin,
+    markdown,
+    markdownUrl,
+    pageTitle,
+    pageUrl,
+    sectionAnchor = '',
+    sectionTitle = '',
+  }) {
+    const context = extractMarkdownSection(markdown, sectionAnchor)
+    const componentExport = componentExportUrl(markdown)
+    const scope = [
+      `- Documentation page: ${pageTitle}`,
+      sectionTitle ? `- Current section: ${sectionTitle}` : null,
+      `- Page: ${pageUrl}`,
+      `- Markdown source: ${markdownUrl}`,
+    ].filter(Boolean)
+    const sources = [
+      `- Documentation index: ${new URL('/llms.txt', docsOrigin).href}`,
+      componentExport ? `- Component documentation export: ${componentExport}` : null,
+      `- Documentation MCP server: ${new URL('/mcp', docsOrigin).href}`,
+    ].filter(Boolean)
+    const instructions = [
+      "1. Read the current project's agent and contributor instructions before changing anything.",
+      '2. Inspect the project and identify where this documentation applies. Do not invent Redpanda commands, fields, or behavior.',
+      '3. If applicable, implement the smallest reversible change and preserve unrelated behavior. If not applicable, explain why and stop.',
+      '4. You may edit and test local files. Before destructive operations, external mutations, or changes to a live ' +
+        'Redpanda environment, show the plan or diff and get my confirmation. Never expose credentials or secrets.',
+      "5. Run the project's relevant checks and any documented Redpanda validation or diff command.",
+      '6. Summarize the changes, verification, remaining manual steps, and any missing or conflicting documentation.',
+    ]
+
+    return `# Apply this Redpanda documentation
+
+Work in the current project. Determine whether this guidance applies, then make the smallest safe update that keeps the project aligned with the current Redpanda pattern.
+
+## Scope
+
+${scope.join('\n')}
+
+## Authoritative Redpanda context
+
+${sources.join('\n')}
+
+## Instructions
+
+${instructions.join('\n')}
+
+## Documentation context
+
+--- BEGIN CURRENT DOCUMENTATION ---
+${context}
+--- END CURRENT DOCUMENTATION ---`
+  }
+
+  return {
+    buildAgentHandoffPrompt,
+    extractMarkdownSection,
+  }
+})

--- a/src/js/14-markdown-dropdown.js
+++ b/src/js/14-markdown-dropdown.js
@@ -9,6 +9,8 @@
  * - Click outside to close
  */
 
+const { buildAgentHandoffPrompt } = window.RedpandaDocsAgentHandoff
+
 ;(function () {
   'use strict'
 
@@ -60,6 +62,14 @@
           setTimeout(function () {
             setOpen(false)
           }, 2500)
+        } else if (action === 'copy-agent') {
+          handleCopyAgent(markdownUrl, item).then(function (didCopy) {
+            if (didCopy) {
+              setTimeout(function () {
+                setOpen(false)
+              }, 2500)
+            }
+          })
         } else if (action === 'view') {
           handleView(markdownUrl)
           setOpen(false)
@@ -152,6 +162,58 @@
           button.classList.remove('clicked')
         },
         function () {} // Empty error handler (matches existing pattern)
+      )
+  }
+
+  function flashCopyStatus (button, message) {
+    const status = button.querySelector('[data-agent-handoff-status]')
+    if (status) status.textContent = message
+
+    button.classList.add('clicked')
+    // Force reflow so the animation can restart.
+    button.offsetHeight // eslint-disable-line no-unused-expressions
+    button.classList.remove('clicked')
+  }
+
+  /**
+   * Copy a complete agent handoff with the current documentation section inline.
+   */
+  function handleCopyAgent (markdownUrl, button) {
+    return window
+      .fetch(markdownUrl)
+      .then(function (response) {
+        if (!response.ok) throw new Error(`Failed to fetch documentation (${response.status})`)
+        return response.text()
+      })
+      .then(function (markdown) {
+        const pageUrl = window.location.href
+        const absoluteMarkdownUrl = new URL(markdownUrl, window.location.origin).href
+        const pageTitle = document.querySelector('h1.page')?.textContent?.trim() || document.title
+        const sectionAnchor = window.location.hash
+        const sectionId = sectionAnchor.replace(/^#/, '')
+        const sectionTitle = document.getElementById(sectionId)?.textContent?.trim() || ''
+        const prompt = buildAgentHandoffPrompt({
+          docsOrigin: window.location.origin,
+          markdown,
+          markdownUrl: absoluteMarkdownUrl,
+          pageTitle,
+          pageUrl,
+          sectionAnchor,
+          sectionTitle,
+        })
+
+        return window.navigator.clipboard.writeText(prompt)
+      })
+      .then(
+        function () {
+          flashCopyStatus(button, 'Copied!')
+          return true
+        },
+        function (error) {
+          console.error('Could not copy agent handoff:', error)
+          flashCopyStatus(button, 'Could not copy. Try again.')
+          return false
+        }
       )
   }
 

--- a/src/js/14-markdown-dropdown.js
+++ b/src/js/14-markdown-dropdown.js
@@ -9,8 +9,6 @@
  * - Click outside to close
  */
 
-const { buildAgentHandoffPrompt } = window.RedpandaDocsAgentHandoff
-
 ;(function () {
   'use strict'
 
@@ -36,6 +34,7 @@ const { buildAgentHandoffPrompt } = window.RedpandaDocsAgentHandoff
     const menu = dropdown.querySelector('.markdown-dropdown-menu')
     const items = dropdown.querySelectorAll('.markdown-dropdown-item')
     const markdownUrl = dropdown.dataset.markdownUrl
+    const componentName = dropdown.dataset.componentName
 
     if (!toggle || !menu || !markdownUrl) {
       return
@@ -63,7 +62,7 @@ const { buildAgentHandoffPrompt } = window.RedpandaDocsAgentHandoff
             setOpen(false)
           }, 2500)
         } else if (action === 'copy-agent') {
-          handleCopyAgent(markdownUrl, item).then(function (didCopy) {
+          handleCopyAgent(markdownUrl, componentName, item).then(function (didCopy) {
             if (didCopy) {
               setTimeout(function () {
                 setOpen(false)
@@ -178,7 +177,14 @@ const { buildAgentHandoffPrompt } = window.RedpandaDocsAgentHandoff
   /**
    * Copy a complete agent handoff with the current documentation section inline.
    */
-  function handleCopyAgent (markdownUrl, button) {
+  function handleCopyAgent (markdownUrl, componentName, button) {
+    const buildAgentHandoffPrompt = window.RedpandaDocsAgentHandoff?.buildAgentHandoffPrompt
+    if (typeof buildAgentHandoffPrompt !== 'function') {
+      console.error('Could not copy agent handoff: prompt builder is unavailable.')
+      flashCopyStatus(button, 'Could not copy. Try again.')
+      return Promise.resolve(false)
+    }
+
     return window
       .fetch(markdownUrl)
       .then(function (response) {
@@ -193,6 +199,7 @@ const { buildAgentHandoffPrompt } = window.RedpandaDocsAgentHandoff
         const sectionId = sectionAnchor.replace(/^#/, '')
         const sectionTitle = document.getElementById(sectionId)?.textContent?.trim() || ''
         const prompt = buildAgentHandoffPrompt({
+          componentName,
           docsOrigin: window.location.origin,
           markdown,
           markdownUrl: absoluteMarkdownUrl,

--- a/src/partials/markdown-dropdown.hbs
+++ b/src/partials/markdown-dropdown.hbs
@@ -1,5 +1,9 @@
 {{#if (has-markdown)}}
-<div class="markdown-dropdown" data-markdown-url="{{markdown-url}}">
+<div
+  class="markdown-dropdown"
+  data-component-name="{{page.component.name}}"
+  data-markdown-url="{{markdown-url}}"
+>
   <button
     class="markdown-dropdown-toggle"
     aria-haspopup="true"

--- a/src/partials/markdown-dropdown.hbs
+++ b/src/partials/markdown-dropdown.hbs
@@ -35,6 +35,24 @@
 
     <button
       class="markdown-dropdown-item"
+      data-action="copy-agent"
+      role="menuitem"
+      type="button"
+    >
+      <svg aria-hidden="true" width="16" height="16" fill="none" viewBox="0 0 16 16">
+        <path d="M2.5 3.5h11v9h-11z" stroke="currentColor"/>
+        <path d="m5 6 2 2-2 2M8.5 10h2.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span>Copy agent handoff</span>
+      <span
+        class="markdown-copy-toast"
+        data-agent-handoff-status
+        role="status"
+      ></span>
+    </button>
+
+    <button
+      class="markdown-dropdown-item"
       data-action="view"
       role="menuitem"
       type="button"

--- a/src/partials/markdown-dropdown.hbs
+++ b/src/partials/markdown-dropdown.hbs
@@ -33,6 +33,7 @@
       <span class="markdown-copy-toast">Copied!</span>
     </button>
 
+    {{#if (has-agent-handoff)}}
     <button
       class="markdown-dropdown-item"
       data-action="copy-agent"
@@ -50,6 +51,7 @@
         role="status"
       ></span>
     </button>
+    {{/if}}
 
     <button
       class="markdown-dropdown-item"

--- a/tests/markdown-dropdown/agent-handoff.test.js
+++ b/tests/markdown-dropdown/agent-handoff.test.js
@@ -1,5 +1,8 @@
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
 const test = require('node:test')
+const vm = require('node:vm')
 
 const {
   buildAgentHandoffPrompt,
@@ -41,9 +44,65 @@ Run the chart test.`
   )
 })
 
+test('extractMarkdownSection maps generated AsciiDoc IDs to Markdown anchors', () => {
+  const generatedAnchorMarkdown = `# Run Claude Code and Codex
+
+## [](#run-codex)Run Codex
+
+Run Codex through AI Gateway.
+
+## [](#make-it-a-shortcut)Make it a shortcut`
+
+  assert.equal(
+    extractMarkdownSection(generatedAnchorMarkdown, '#_run_codex'),
+    `## [](#run-codex)Run Codex
+
+Run Codex through AI Gateway.`
+  )
+})
+
 test('extractMarkdownSection falls back to the full page without a matching anchor', () => {
   assert.equal(extractMarkdownSection(markdown, '#missing'), markdown)
   assert.equal(extractMarkdownSection(markdown, ''), markdown)
+})
+
+test('extractMarkdownSection ignores heading-like lines inside fenced code blocks', () => {
+  const fencedMarkdown = `# Draw charts
+
+\`\`\`text
+## [](#migrate-chart-js-prompt)Not the section heading
+\`\`\`
+
+## [](#migrate-chart-js-prompt)Migrate from Chart.js
+
+Keep bar and line charts.
+
+\`\`\`yaml
+# This comment is not a heading
+type: bar
+\`\`\`
+
+### [](#verification)Verify the migration
+
+Run the chart test.
+
+## [](#troubleshooting)Troubleshooting`
+
+  assert.equal(
+    extractMarkdownSection(fencedMarkdown, '#migrate-chart-js-prompt'),
+    `## [](#migrate-chart-js-prompt)Migrate from Chart.js
+
+Keep bar and line charts.
+
+\`\`\`yaml
+# This comment is not a heading
+type: bar
+\`\`\`
+
+### [](#verification)Verify the migration
+
+Run the chart test.`
+  )
 })
 
 test('buildAgentHandoffPrompt copies actionable context and canonical sources', () => {
@@ -100,10 +159,11 @@ Run the chart test.
   )
 })
 
-test('buildAgentHandoffPrompt includes the component export advertised by the page', () => {
+test('buildAgentHandoffPrompt derives the component export without parsing footer copy', () => {
   const prompt = buildAgentHandoffPrompt({
+    componentName: 'agentic-data-plane',
     docsOrigin: 'https://docs.redpanda.com',
-    markdown: `> Component-specific: [agentic-data-plane-full.txt](https://docs.redpanda.com/agentic-data-plane-full.txt)
+    markdown: `> Browse the complete documentation index in llms.txt.
 
 # Configure a provider`,
     markdownUrl:
@@ -117,4 +177,26 @@ test('buildAgentHandoffPrompt includes the component export advertised by the pa
     prompt,
     /- Component documentation export: https:\/\/docs\.redpanda\.com\/agentic-data-plane-full\.txt/
   )
+})
+
+test('markdown dropdown loads when the optional agent handoff module is unavailable', () => {
+  const dropdownScript = fs.readFileSync(
+    path.join(__dirname, '../../src/js/14-markdown-dropdown.js'),
+    'utf8'
+  )
+  const documentListeners = new Map()
+
+  assert.doesNotThrow(() => {
+    vm.runInNewContext(dropdownScript, {
+      console,
+      document: {
+        addEventListener: (event, listener) => documentListeners.set(event, listener),
+        readyState: 'loading',
+      },
+      setTimeout,
+      URL,
+      window: {},
+    })
+  })
+  assert.equal(typeof documentListeners.get('DOMContentLoaded'), 'function')
 })

--- a/tests/markdown-dropdown/agent-handoff.test.js
+++ b/tests/markdown-dropdown/agent-handoff.test.js
@@ -1,0 +1,120 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  buildAgentHandoffPrompt,
+  extractMarkdownSection,
+} = require('../../src/js/13-agent-handoff')
+
+const markdown = `# Draw charts
+
+Page introduction.
+
+## [](#chart-contract)Chart contract
+
+Use a \`chart\` fence.
+
+## [](#migrate-chart-js-prompt)Migrate from Chart.js
+
+Keep bar and line charts.
+
+### [](#verification)Verify the migration
+
+Run the chart test.
+
+## [](#troubleshooting)Troubleshooting
+
+Review the rendered error.`
+
+test('extractMarkdownSection returns the anchored section and its children', () => {
+  const section = extractMarkdownSection(markdown, '#migrate-chart-js-prompt')
+
+  assert.equal(
+    section,
+    `## [](#migrate-chart-js-prompt)Migrate from Chart.js
+
+Keep bar and line charts.
+
+### [](#verification)Verify the migration
+
+Run the chart test.`
+  )
+})
+
+test('extractMarkdownSection falls back to the full page without a matching anchor', () => {
+  assert.equal(extractMarkdownSection(markdown, '#missing'), markdown)
+  assert.equal(extractMarkdownSection(markdown, ''), markdown)
+})
+
+test('buildAgentHandoffPrompt copies actionable context and canonical sources', () => {
+  const prompt = buildAgentHandoffPrompt({
+    docsOrigin: 'https://docs.redpanda.com',
+    markdown,
+    markdownUrl:
+      'https://docs.redpanda.com/agentic-data-plane/connect/draw-charts.md',
+    pageTitle: 'Draw charts',
+    pageUrl:
+      'https://docs.redpanda.com/agentic-data-plane/connect/draw-charts/#migrate-chart-js-prompt',
+    sectionAnchor: '#migrate-chart-js-prompt',
+    sectionTitle: 'Migrate from Chart.js',
+  })
+
+  assert.equal(
+    prompt,
+    `# Apply this Redpanda documentation
+
+Work in the current project. Determine whether this guidance applies, then make the smallest safe update that keeps the project aligned with the current Redpanda pattern.
+
+## Scope
+
+- Documentation page: Draw charts
+- Current section: Migrate from Chart.js
+- Page: https://docs.redpanda.com/agentic-data-plane/connect/draw-charts/#migrate-chart-js-prompt
+- Markdown source: https://docs.redpanda.com/agentic-data-plane/connect/draw-charts.md
+
+## Authoritative Redpanda context
+
+- Documentation index: https://docs.redpanda.com/llms.txt
+- Documentation MCP server: https://docs.redpanda.com/mcp
+
+## Instructions
+
+1. Read the current project's agent and contributor instructions before changing anything.
+2. Inspect the project and identify where this documentation applies. Do not invent Redpanda commands, fields, or behavior.
+3. If applicable, implement the smallest reversible change and preserve unrelated behavior. If not applicable, explain why and stop.
+4. You may edit and test local files. Before destructive operations, external mutations, or changes to a live Redpanda environment, show the plan or diff and get my confirmation. Never expose credentials or secrets.
+5. Run the project's relevant checks and any documented Redpanda validation or diff command.
+6. Summarize the changes, verification, remaining manual steps, and any missing or conflicting documentation.
+
+## Documentation context
+
+--- BEGIN CURRENT DOCUMENTATION ---
+## [](#migrate-chart-js-prompt)Migrate from Chart.js
+
+Keep bar and line charts.
+
+### [](#verification)Verify the migration
+
+Run the chart test.
+--- END CURRENT DOCUMENTATION ---`
+  )
+})
+
+test('buildAgentHandoffPrompt includes the component export advertised by the page', () => {
+  const prompt = buildAgentHandoffPrompt({
+    docsOrigin: 'https://docs.redpanda.com',
+    markdown: `> Component-specific: [agentic-data-plane-full.txt](https://docs.redpanda.com/agentic-data-plane-full.txt)
+
+# Configure a provider`,
+    markdownUrl:
+      'https://docs.redpanda.com/agentic-data-plane/gateway/configure-provider.md',
+    pageTitle: 'Configure a provider',
+    pageUrl:
+      'https://docs.redpanda.com/agentic-data-plane/gateway/configure-provider/',
+  })
+
+  assert.match(
+    prompt,
+    /- Component documentation export: https:\/\/docs\.redpanda\.com\/agentic-data-plane-full\.txt/
+  )
+})

--- a/tests/markdown-dropdown/visibility.test.js
+++ b/tests/markdown-dropdown/visibility.test.js
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const handlebars = require('handlebars')
+const hasAgentHandoff = require('../../src/helpers/has-agent-handoff')
+
+const partial = fs.readFileSync(
+  path.join(__dirname, '../../src/partials/markdown-dropdown.hbs'),
+  'utf8'
+)
+
+handlebars.registerHelper('has-markdown', () => true)
+handlebars.registerHelper('has-agent-handoff', hasAgentHandoff)
+
+const renderDropdown = handlebars.compile(partial)
+
+test('renders the agent handoff action only for pages that opt in', () => {
+  const disabled = renderDropdown({ page: { attributes: {} } })
+  const enabled = renderDropdown({
+    page: { attributes: { 'agent-handoff': '' } },
+  })
+
+  assert.doesNotMatch(disabled, /data-action="copy-agent"/)
+  assert.match(enabled, /data-action="copy-agent"/)
+})

--- a/tests/markdown-dropdown/visibility.test.js
+++ b/tests/markdown-dropdown/visibility.test.js
@@ -19,9 +19,13 @@ const renderDropdown = handlebars.compile(partial)
 test('renders the agent handoff action only for pages that opt in', () => {
   const disabled = renderDropdown({ page: { attributes: {} } })
   const enabled = renderDropdown({
-    page: { attributes: { 'agent-handoff': '' } },
+    page: {
+      attributes: { 'agent-handoff': '' },
+      component: { name: 'agentic-data-plane' },
+    },
   })
 
   assert.doesNotMatch(disabled, /data-action="copy-agent"/)
   assert.match(enabled, /data-action="copy-agent"/)
+  assert.match(enabled, /data-component-name="agentic-data-plane"/)
 })


### PR DESCRIPTION
## Summary

- Add an opt-in **Copy agent handoff** action to Page options.
- Copy a vendor-neutral, actionable prompt with the current anchored section inline.
- Point agents to `llms.txt`, the docs MCP server, and a deterministic component full export URL.
- Keep existing Page options working if the optional handoff module is unavailable.
- Ignore heading-like lines inside fenced examples when extracting the current section.
- Show visible copy/fetch failures and keep the menu open so users can retry.
- Leave the action hidden unless the individual page enables `page-agent-handoff`.
- Assign the documentation team as owner of the customer-facing prompt wording.

## Why

ADP customers often reach documentation from product UI badges while changing code, configuration, or migrations. This creates the reverse handoff: docs to a coding agent, with enough scoped context to inspect the project and safely apply the documented pattern.

The prompt permits local edits and tests, but requires confirmation before destructive operations, external mutations, or changes to a live Redpanda environment.

## Paired content change

[redpanda-data/adp-docs#170](https://github.com/redpanda-data/adp-docs/pull/170) enables a one-page pilot on **Run Claude Code and Codex through AI Gateway**. Other Agentic Data Plane and Redpanda documentation pages remain unchanged.

## Verification

- `npm run test:markdown-dropdown` (8 tests)
- `npx gulp lint`
- `npx gulp bundle`
- Combined Antora build with the paired ADP branch and local UI bundle

### Surface review

| Surface | Result |
| --- | --- |
| Pilot page, anchored **Run Codex** section | Pass: copied prompt starts at that section, excludes the next peer section, and includes the component export and safety guardrail |
| Missing optional handoff module | Pass: existing Markdown copy still works; the handoff action reports a contained error |
| Non-opted ADP page | Pass: existing Page options remain; agent handoff is absent |
| Fenced heading-like examples | Pass: comments inside fences do not change section boundaries |

## Follow-ups

- Pilot the action on Redpanda Connect cookbooks after validating their Markdown exports.
- Add an explicitly authored **Migrate with an agent** action for actionable release notes.
- Consider product-side deep links into documented agent handoffs.
- Evaluate direct Claude/Codex launching after the copy-first workflow is validated.
