### PR TITLE
Hide Make a contribution CTA/modal on pages from private repos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,6 @@
 :url-redpanda: https://redpanda.com
 :url-antora: https://antora.org/
 :hide-uri-scheme:
-:url-contributing: {url-site}/blob/main/meta-docs/CONTRIBUTING.adoc
 :url-netlify: https://netlify.com
 :url-netlify-docs: https://docs.netlify.com
 :url-antora-docs: https://docs.antora.org

--- a/src/partials/contributors-modal.hbs
+++ b/src/partials/contributors-modal.hbs
@@ -23,16 +23,14 @@
         </div>
         {{/with}}
       </div>
+      {{#if (eq page.component.name 'labs')}}
       <div class="modal-column">
         <h3>Contribution guide</h3>
         <p>For extensive content updates, or if you prefer to work locally, read our
-        {{#if (eq page.component.name 'labs')}}
         <a href="/labs/contribute/" target="_blank" rel="noopener noreferrer"><span>contribution guide</span></a>
-        {{else}}
-        <a href="https://github.com/redpanda-data/docs-site/blob/main/meta-docs/CONTRIBUTING.adoc" target="_blank" rel="noopener noreferrer"><span>contribution guide</span></a>
-        {{/if}}
         .</p>
       </div>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/src/partials/feedback-footer.hbs
+++ b/src/partials/feedback-footer.hbs
@@ -1,5 +1,7 @@
 {{#if (ne page.attributes.role 'home')}}
+{{#if (not page.origin.private)}}
 {{> contributors-modal}}
+{{/if}}
 <section class="feedback-section">
   {{> thumbs}}
   <div class="col">
@@ -13,12 +15,14 @@
       <span> Share your feedback</span>
     </a>
   </div>
+  {{#if (not page.origin.private)}}
   <div class="col">
     <a href="#" aria-label="See options for contributing" onclick="handleModal(event)" rel="nofollow">
       <span class="material-symbols-outlined">group_add</span>
       <span>Make a contribution</span>
     </a>
   </div>
+  {{/if}}
 </section>
 {{> feedback-success}}
 <script>


### PR DESCRIPTION
## Description

Related to https://redpandadata.atlassian.net/browse/DOC-2303 (making `docs`, `cloud-docs`, `rp-connect-docs`, `adp-docs` private).

### 1. Hide the "Make a contribution" CTA/modal on private-origin pages

The feedback footer's "Make a contribution" button opens a modal offering "Edit on GitHub" and a link to the contribution guide — a flow that only works when the underlying repo is public. The modal already hides its own "Edit on GitHub" link via `page.origin.private` (Antora's own per-page privacy flag), but the outer button + modal still rendered regardless, misleadingly inviting a contribution path that no longer works for external contributors.

This applies the same `page.origin.private` check one level up, so the whole button and modal are hidden together on pages sourced from a private repo. Still-public components (`docs-site`, `labs`) are unaffected — nothing hardcoded to specific component names, so this holds automatically for any future component that goes private too.

### 2. Drop the modal's now-dead generic "Contribution guide" link

For pages that stay public, the modal's second column pointed at `docs-site/meta-docs/CONTRIBUTING.adoc`. That file is being removed (redpanda-data/docs-site#201) since it described a fork-and-clone workflow that no longer works once the four repos above go private. There's no public replacement destination, so the column is dropped entirely rather than repointed — it only remains for the Labs branch, which stays public with its own separate guide (`/labs/contribute/`). Also removes README's `:url-contributing:` attribute, which pointed at the same removed file and wasn't referenced anywhere else in the doc.

## What was checked

- `src/css/feedback-footer.css` - `.feedback-section` uses `display: flex` / `justify-content: space-between` with no `nth-child` or fixed-count assumptions, so dropping columns doesn't break layout.
- The inner "Edit on GitHub" check in `contributors-modal.hbs` is now redundant given the outer gate, but left in place as a harmless belt-and-suspenders check.

## Related PRs

- redpanda-data/docs-site#201 — relocates/splits the contribution guide
- redpanda-data/cupboard#676 — archives the external-contribution process internally