### PR TITLE
fix(chat-panel): constrain images in Kapa answers to panel width

### DIFF
--- a/src/css/chat-panel-bump.css
+++ b/src/css/chat-panel-bump.css
@@ -241,6 +241,12 @@
   margin: 0;
 }
 
+/* Images - constrain to the panel width (Kapa answers can include images) */
+#chat-panel-kapa-root img {
+  max-width: 100%;
+  height: auto;
+}
+
 #chat-panel-kapa-root .answer ul,
 #chat-panel-kapa-root .answer ol {
   margin: 8px 0;

--- a/src/css/chat-panel.css
+++ b/src/css/chat-panel.css
@@ -241,6 +241,12 @@
   margin: 0;
 }
 
+/* Images - constrain to the panel width (Kapa answers can include images) */
+#chat-panel-kapa-root img {
+  max-width: 100%;
+  height: auto;
+}
+
 #chat-panel-kapa-root .answer ul,
 #chat-panel-kapa-root .answer ol {
   margin: 8px 0;


### PR DESCRIPTION
## Summary

Kapa flagged a rendering issue in our Ask AI widget since they launched image support: when an answer includes an image, it renders at natural width with no limit, which stretches the answer column sideways and clips the image, code, and text on the right.

This applies Kapa's recommended fix, scoped under our chat panel root:

```css
#chat-panel-kapa-root img {
  max-width: 100%;
  height: auto;
}
```

## Changes

- `src/css/chat-panel.css` - main docs site chat panel
- `src/css/chat-panel-bump.css` - Ask AI drawer widget on the Bump.sh API reference pages (duplicates the panel styles, so it needs the same rule)

The compiled widget CSS under `src/static/assets/widgets/css/` is gitignored build output and gets regenerated by `gulp compile:widgets` during bundling.

## Preview pages

- [Deploy preview](https://deploy-preview-412--docs-ui.netlify.app/) - open the Ask AI widget on any page to check the image fix

## Testing

- `gulp lint` passes
- The fix reaches production with the next ui-bundle release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
