### PR TITLE
DOC-2303: Make the contribution CTA opt-in via page-contribution attribute

### DIFF
--- a/src/partials/feedback-footer.hbs
+++ b/src/partials/feedback-footer.hbs
@@ -1,5 +1,5 @@
 {{#if (ne page.attributes.role 'home')}}
-{{#if (not page.origin.private)}}
+{{#if page.attributes.contribution}}
 {{> contributors-modal}}
 {{/if}}
 <section class="feedback-section">
@@ -15,7 +15,7 @@
       <span> Share your feedback</span>
     </a>
   </div>
-  {{#if (not page.origin.private)}}
+  {{#if page.attributes.contribution}}
   <div class="col">
     <a href="#" aria-label="See options for contributing" onclick="handleModal(event)" rel="nofollow">
       <span class="material-symbols-outlined">group_add</span>

--- a/src/partials/feedback-footer.hbs
+++ b/src/partials/feedback-footer.hbs
@@ -1,5 +1,5 @@
 {{#if (ne page.attributes.role 'home')}}
-{{#if page.attributes.contribution}}
+{{#if (and (ne page.attributes.contribution undefined) (ne page.attributes.contribution 'false'))}}
 {{> contributors-modal}}
 {{/if}}
 <section class="feedback-section">
@@ -15,7 +15,7 @@
       <span> Share your feedback</span>
     </a>
   </div>
-  {{#if page.attributes.contribution}}
+  {{#if (and (ne page.attributes.contribution undefined) (ne page.attributes.contribution 'false'))}}
   <div class="col">
     <a href="#" aria-label="See options for contributing" onclick="handleModal(event)" rel="nofollow">
       <span class="material-symbols-outlined">group_add</span>


### PR DESCRIPTION
Part of [DOC-2303](https://redpandadata.atlassian.net/browse/DOC-2303). Follow-up to #410.

## Problem

The `page.origin.private` detection from #410 has gaps now that the content repos are private:

- Pages built from a local worktree origin (docs-site's own `url: .` components: data-platform, self-managed) are never marked private, so they keep a CTA whose Edit on GitHub / Open an issue links 404 for readers outside the org.
- The CTA still renders on cloud pages in production after the v3.2.1 deploy, so detection is unreliable in at least one real build context.

## Change

Flip the model from detection to **opt-in**: the Make a contribution CTA (and the contributors modal it opens) render only when the page carries the `page-contribution` attribute:

```yaml
# component antora.yml
asciidoc:
  attributes:
    page-contribution: 'true'
```

Default is hidden everywhere. redpanda-labs (still public, community contributions welcome) opts in via redpanda-data/redpanda-labs#292. The Ask-in-the-community and Share-your-feedback links are unaffected.

The modal's internal edit-link logic (`page.editUrl` / `FORCE_SHOW_EDIT_PAGE_LINK` / `origin.private`) is unchanged: it still governs which links appear for pages that do opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2303]: https://redpandadata.atlassian.net/browse/DOC-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ