### PR TITLE
DOC-2432: open external and attachment links in a new tab (+ download glyph)

### DIFF
--- a/preview-src/link-targets-test.adoc
+++ b/preview-src/link-targets-test.adoc
@@ -29,4 +29,5 @@ Redpanda Console runs locally at http://localhost:8080/login[Console on localhos
 == Next steps
 
 * For production, see the internal docs: https://docs.redpanda.com/current/deploy/redpanda/kubernetes/[Kubernetes deployment guides] — an internal `docs.redpanda.com` link, so no icon and same tab.
-* A link written with `^` still works and is not double-targeted: https://www.redpanda.com/[Redpanda home^].
+* An internal link written with `^` opens in a new tab but shows no icon (it's on `docs.redpanda.com`): https://docs.redpanda.com/current/get-started/intro-to-events/[Intro to events^]. It should still get `rel="noopener"` and the "(opens in a new tab)" hint.
+* An external link written with `^` still works and is not double-targeted: https://www.redpanda.com/[Redpanda home^].

--- a/preview-src/link-targets-test.adoc
+++ b/preview-src/link-targets-test.adoc
@@ -26,6 +26,15 @@ The profile is configured in the pass:[<a class="attachment" href="rpk-profile.y
 
 Redpanda Console runs locally at http://localhost:8080/login[Console on localhost:8080], and the object store UI is at http://localhost:9001/browser[MinIO on localhost:9001]. These now open in a new tab too.
 
+== Hardening cases
+
+These exercise the URL parsing in the JS (hostname comparison, not substring matching):
+
+* An external URL that mentions an internal host in its *path* still opens in a new tab: https://example.com/docs.redpanda.com/fake[example.com/docs.redpanda.com/...]. (The CSS icon rule is substring-based, so this link shows no icon — a known, cosmetic-only divergence.)
+* An external host that merely ends with an internal host's spelling is still external: https://fakenetlify.app.example.com/[fakenetlify.app.example.com] — new tab. Real subdomains such as `deploy-preview-417--docs-ui.netlify.app` stay internal.
+* A `mailto:` link is untouched — same tab semantics, no icon, no hint: mailto:support@redpanda.com[email support].
+* An explicit `target` set by the author is respected and not overridden: pass:[<a href="https://www.redpanda.com/blog" target="_self">redpanda.com blog, forced same-tab</a>].
+
 == Next steps
 
 * For production, see the internal docs: https://docs.redpanda.com/current/deploy/redpanda/kubernetes/[Kubernetes deployment guides] — an internal `docs.redpanda.com` link, so no icon and same tab.

--- a/preview-src/link-targets-test.adoc
+++ b/preview-src/link-targets-test.adoc
@@ -1,0 +1,30 @@
+= Link target test
+// Sample page for verifying link behavior in a local preview: external,
+// internal, localhost, and attachment links. Exercises the rules in
+// src/js/26-open-external-and-attachment-links.js and the a[href*="//"] /
+// a.attachment ::after rules in doc.css.
+
+Inspect each link (or click through) to check `target="_blank"`, the icons, and the visually-hidden "(opens in a new tab)" phrase that screen readers announce.
+
+== External links (external icon + new tab)
+
+None of these use the `^` suffix; the JS still opens them in a new tab and announces it:
+
+* https://github.com/redpanda-data/redpanda[Redpanda on GitHub]
+* https://kubernetes.io/docs/home/[Kubernetes documentation]
+
+A link written with `^` still gets the hint and isn't double-targeted: https://redpanda.com/[Redpanda home^].
+
+== Internal link (no icon, same tab)
+
+* https://docs.redpanda.com/current/get-started/quick-start/[Quickstart]
+
+== localhost (external icon + new tab)
+
+* http://localhost:8080/login[Local Redpanda Console]
+
+== Attachment / download link (download glyph + new tab)
+
+// Raw anchor carrying the .attachment class that Antora adds to
+// xref:...attachment$... links, so the sample needs no real published attachment.
+pass:[<a class="attachment" href="sample.yaml">docker-compose/rpk-profile.yaml file</a>]

--- a/preview-src/link-targets-test.adoc
+++ b/preview-src/link-targets-test.adoc
@@ -1,30 +1,32 @@
-= Link target test
-// Sample page for verifying link behavior in a local preview: external,
-// internal, localhost, and attachment links. Exercises the rules in
-// src/js/26-open-external-and-attachment-links.js and the a[href*="//"] /
-// a.attachment ::after rules in doc.css.
+= Quickstart link preview
+// Dev-only sample page. It reproduces the LINK TYPES on the real Redpanda
+// quickstart (external, internal, localhost, attachment) so a local or deploy
+// preview shows how each behaves: icons, open-in-new-tab, and the visually
+// hidden "(opens in a new tab)" hint. This is NOT the real quickstart (which
+// lives in the docs repo and depends on its modules/attachments) — it just
+// mirrors its links. Exercises src/js/26-open-external-and-attachment-links.js
+// and the a[href*="//"] / a.attachment ::after rules in doc.css.
 
-Inspect each link (or click through) to check `target="_blank"`, the icons, and the visually-hidden "(opens in a new tab)" phrase that screen readers announce.
+This page mirrors the link types on the Redpanda quickstart. None of the external links below use the `^` suffix — the docs-ui rule opens them in a new tab anyway (which is what makes the per-link `^` unnecessary).
 
-== External links (external icon + new tab)
+== Deploy Redpanda
 
-None of these use the `^` suffix; the JS still opens them in a new tab and announces it:
+This quickstart uses Docker. To download the Redpanda binary, see https://github.com/redpanda-data/redpanda/releases/latest[GitHub]. For a managed option, sign up for https://cloud.redpanda.com[Redpanda Cloud].
 
-* https://github.com/redpanda-data/redpanda[Redpanda on GitHub]
-* https://kubernetes.io/docs/home/[Kubernetes documentation]
+For Docker Compose, see the https://docs.docker.com/compose/install/[Docker Compose documentation]. On Windows, use https://learn.microsoft.com/windows/wsl/install[Windows Subsystem for Linux].
 
-A link written with `^` still gets the hint and isn't double-targeted: https://redpanda.com/[Redpanda home^].
+[NOTE]
+====
+The source code for the data transform function is in the pass:[<a class="attachment" href="transform.go"><code>docker-compose/transform/transform.go</code> file</a>] that you downloaded. This file is commented to explain how it works.
+====
 
-== Internal link (no icon, same tab)
+The profile is configured in the pass:[<a class="attachment" href="rpk-profile.yaml"><code>docker-compose/rpk-profile.yaml</code> file</a>] that you downloaded.
 
-* https://docs.redpanda.com/current/get-started/quick-start/[Quickstart]
+== Explore Redpanda Console
 
-== localhost (external icon + new tab)
+Redpanda Console runs locally at http://localhost:8080/login[Console on localhost:8080], and the object store UI is at http://localhost:9001/browser[MinIO on localhost:9001]. These now open in a new tab too.
 
-* http://localhost:8080/login[Local Redpanda Console]
+== Next steps
 
-== Attachment / download link (download glyph + new tab)
-
-// Raw anchor carrying the .attachment class that Antora adds to
-// xref:...attachment$... links, so the sample needs no real published attachment.
-pass:[<a class="attachment" href="sample.yaml">docker-compose/rpk-profile.yaml file</a>]
+* For production, see the internal docs: https://docs.redpanda.com/current/deploy/redpanda/kubernetes/[Kubernetes deployment guides] — an internal `docs.redpanda.com` link, so no icon and same tab.
+* A link written with `^` still works and is not double-targeted: https://www.redpanda.com/[Redpanda home^].

--- a/src/css/doc-bump.css
+++ b/src/css/doc-bump.css
@@ -210,6 +210,15 @@ html[data-theme=dark] {
   filter: var(--external-link-filter);
 }
 
+/* On-site attachment/download links: download glyph (see doc.css and
+   src/js/26-open-external-and-attachment-links.js). */
+.aa-DetachedOverlay .doc a.attachment::after {
+  content: url('/_/img/download.svg');
+  position: relative;
+  margin-left: 2px;
+  filter: var(--external-link-filter);
+}
+
 .aa-DetachedOverlay .doc i.fa {
   hyphens: none;
   font-style: normal;

--- a/src/css/doc-bump.css
+++ b/src/css/doc-bump.css
@@ -203,7 +203,7 @@ html[data-theme=dark] {
 }
 */
 
-.aa-DetachedOverlay .doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not([href*="localhost"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after {
+.aa-DetachedOverlay .doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after {
   content: url('/_/img/external-link.svg');
   position: relative;
   margin-left: 2px;

--- a/src/css/doc-bump.css
+++ b/src/css/doc-bump.css
@@ -219,6 +219,20 @@ html[data-theme=dark] {
   filter: var(--external-link-filter);
 }
 
+/* The visually-hidden "(opens in a new tab)" phrase appended by
+   26-open-external-and-attachment-links.js (see doc.css). */
+.aa-DetachedOverlay .doc .doc-new-tab-hint {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .aa-DetachedOverlay .doc i.fa {
   hyphens: none;
   font-style: normal;

--- a/src/css/doc-bump.css
+++ b/src/css/doc-bump.css
@@ -212,7 +212,7 @@ html[data-theme=dark] {
 
 /* On-site attachment/download links: download glyph (see doc.css and
    src/js/26-open-external-and-attachment-links.js). */
-.aa-DetachedOverlay .doc a.attachment::after {
+.aa-DetachedOverlay .doc a.attachment[href]::after {
   content: url('/_/img/download.svg');
   position: relative;
   margin-left: 2px;

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -741,7 +741,7 @@ html[data-theme="dark"] .status-badge--self-managed-only {
    xref:...attachment$... links). They open in a new tab (see
    26-open-external-and-attachment-links.js) and get a download glyph, distinct
    from the external-link icon, so the new-tab behavior is signaled. */
-.doc a.attachment::after {
+.doc a.attachment[href]::after {
   content: url('/_/img/download.svg');
   position: relative;
   margin-left: 2px;

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -730,7 +730,7 @@ html[data-theme="dark"] .status-badge--self-managed-only {
    The matching new-tab behavior is applied in
    src/js/26-open-external-and-attachment-links.js — keep the excluded-host
    list below in sync with the selector in that file. */
-.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not([href*="localhost"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after {
+.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after {
   content: url('/_/img/external-link.svg');
   position: relative;
   margin-left: 2px;

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -728,8 +728,10 @@ html[data-theme="dark"] .status-badge--self-managed-only {
 
 /* External (off-site) links get the external-link icon and open in a new tab.
    The matching new-tab behavior is applied in
-   src/js/26-open-external-and-attachment-links.js — keep the excluded-host
-   list below in sync with the selector in that file. */
+   src/js/26-open-external-and-attachment-links.js, which parses each URL and
+   compares hostnames; the substring :not() exclusions below approximate that
+   policy (the best CSS can do). Keep the excluded hosts in sync with the
+   INTERNAL_HOSTS list in that file. */
 .doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after {
   content: url('/_/img/external-link.svg');
   position: relative;
@@ -746,6 +748,22 @@ html[data-theme="dark"] .status-badge--self-managed-only {
   position: relative;
   margin-left: 2px;
   filter: var(--external-link-filter);
+}
+
+/* The visually-hidden "(opens in a new tab)" phrase that
+   26-open-external-and-attachment-links.js appends to new-tab links for
+   screen readers. Defined here (not via home.css's .visually-hidden) so the
+   hint doesn't depend on another stylesheet staying global. */
+.doc-new-tab-hint {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .doc i.fa {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -726,8 +726,23 @@ html[data-theme="dark"] .status-badge--self-managed-only {
 }
 */
 
+/* External (off-site) links get the external-link icon and open in a new tab.
+   The matching new-tab behavior is applied in
+   src/js/26-open-external-and-attachment-links.js — keep the excluded-host
+   list below in sync with the selector in that file. */
 .doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not([href*="localhost"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after {
   content: url('/_/img/external-link.svg');
+  position: relative;
+  margin-left: 2px;
+  filter: var(--external-link-filter);
+}
+
+/* On-site attachment/download links (Antora adds .attachment to
+   xref:...attachment$... links). They open in a new tab (see
+   26-open-external-and-attachment-links.js) and get a download glyph, distinct
+   from the external-link icon, so the new-tab behavior is signaled. */
+.doc a.attachment::after {
+  content: url('/_/img/download.svg');
   position: relative;
   margin-left: 2px;
   filter: var(--external-link-filter);

--- a/src/img/download.svg
+++ b/src/img/download.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>

--- a/src/js/26-open-external-and-attachment-links.js
+++ b/src/js/26-open-external-and-attachment-links.js
@@ -34,13 +34,15 @@
 
   function process (a) {
     // Respect an explicit target the author or a widget already set: only add a
-    // new tab where none was requested. Still announce any link that ends up
-    // opening in a new tab, including ^-suffixed links that already carry it.
-    if (!a.hasAttribute('target')) {
-      a.setAttribute('target', '_blank')
+    // new tab where none was requested. But any link that opens in a new tab
+    // must carry rel="noopener" (reverse-tabnabbing protection) and announce
+    // itself to assistive tech — including ^-suffixed or widget-set links that
+    // already have target="_blank" but may be missing rel.
+    if (!a.hasAttribute('target')) a.setAttribute('target', '_blank')
+    if (a.getAttribute('target') === '_blank') {
       ensureRel(a)
+      addHint(a)
     }
-    if (a.getAttribute('target') === '_blank') addHint(a)
   }
 
   function run () {

--- a/src/js/26-open-external-and-attachment-links.js
+++ b/src/js/26-open-external-and-attachment-links.js
@@ -45,17 +45,28 @@
     }
   }
 
+  // Links inside the feedback widget and the search autocomplete are excluded
+  // (matching the icon CSS) so we don't annotate or restyle UI chrome.
+  function isExcluded (a) {
+    return !!(a.closest('section.feedback-section') || a.closest('.aa-ItemIcon'))
+  }
+
   function run () {
-    const external = document.querySelectorAll(
+    // External off-site links -> open in a new tab.
+    document.querySelectorAll(
       '.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"])'
-    )
-    external.forEach(function (a) {
-      if (a.closest('section.feedback-section') || a.closest('.aa-ItemIcon')) return
-      process(a)
-    })
+    ).forEach(function (a) { if (!isExcluded(a)) process(a) })
 
     // On-site attachment/download links (the _attachments files).
     document.querySelectorAll('.doc a.attachment[href]').forEach(process)
+
+    // Any remaining link that already opens in a new tab -- e.g. an internal or
+    // relative ^-suffixed link that the two passes above don't match -- still
+    // needs rel="noopener" and the screen-reader hint. process() is idempotent,
+    // so links already handled above are unaffected.
+    document.querySelectorAll('.doc a[target="_blank"]').forEach(function (a) {
+      if (!isExcluded(a)) process(a)
+    })
   }
 
   if (document.readyState === 'loading') {

--- a/src/js/26-open-external-and-attachment-links.js
+++ b/src/js/26-open-external-and-attachment-links.js
@@ -1,0 +1,42 @@
+;(function () {
+  'use strict'
+
+  // Open external (off-site) links and on-site attachment/download links in a
+  // new tab, so readers don't lose their place in the current page.
+  //
+  // The external-link selector below MIRRORS the CSS rule that renders the
+  // external-link icon in src/css/doc.css (and src/css/doc-bump.css). Keep the
+  // two in sync: if you change the excluded hosts here, change them there too.
+  // Attachment links are matched by the `.attachment` class Antora adds to
+  // `xref:...attachment$...` links; they get the download glyph via CSS.
+
+  function markNewTab (a) {
+    if (a.hasAttribute('target')) return
+    a.setAttribute('target', '_blank')
+    const rel = (a.getAttribute('rel') || '').split(/\s+/).filter(Boolean)
+    if (rel.indexOf('noopener') === -1) rel.push('noopener')
+    a.setAttribute('rel', rel.join(' '))
+  }
+
+  function run () {
+    // External, off-site links. The attribute-based :not() chain matches the
+    // doc.css selector; the feedback-section / autocomplete exclusions are
+    // applied in JS via closest() for broader browser support.
+    const external = document.querySelectorAll(
+      '.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not([href*="localhost"])'
+    )
+    external.forEach(function (a) {
+      if (a.closest('section.feedback-section') || a.closest('.aa-ItemIcon')) return
+      markNewTab(a)
+    })
+
+    // On-site attachment/download links (the _attachments files).
+    document.querySelectorAll('.doc a.attachment[href]').forEach(markNewTab)
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run)
+  } else {
+    run()
+  }
+})()

--- a/src/js/26-open-external-and-attachment-links.js
+++ b/src/js/26-open-external-and-attachment-links.js
@@ -2,36 +2,58 @@
   'use strict'
 
   // Open external (off-site) links and on-site attachment/download links in a
-  // new tab, so readers don't lose their place in the current page.
+  // new tab, and announce that to assistive tech, so readers don't silently
+  // lose their place in the current page.
   //
   // The external-link selector below MIRRORS the CSS rule that renders the
   // external-link icon in src/css/doc.css (and src/css/doc-bump.css). Keep the
   // two in sync: if you change the excluded hosts here, change them there too.
+  // (localhost is intentionally NOT excluded: a link to a local app opens a
+  // different origin, so a new tab keeps the docs page in place.)
   // Attachment links are matched by the `.attachment` class Antora adds to
   // `xref:...attachment$...` links; they get the download glyph via CSS.
 
-  function markNewTab (a) {
-    if (a.hasAttribute('target')) return
-    a.setAttribute('target', '_blank')
+  const HINT_CLASS = 'doc-new-tab-hint'
+
+  function ensureRel (a) {
     const rel = (a.getAttribute('rel') || '').split(/\s+/).filter(Boolean)
     if (rel.indexOf('noopener') === -1) rel.push('noopener')
     a.setAttribute('rel', rel.join(' '))
   }
 
+  // Append a visually-hidden phrase so screen readers announce the new tab.
+  // The external-link / download icons are decorative CSS and are not exposed
+  // to assistive tech, so this is the only signal AT users get.
+  function addHint (a) {
+    if (a.querySelector('.' + HINT_CLASS)) return
+    const hint = document.createElement('span')
+    hint.className = 'visually-hidden ' + HINT_CLASS
+    hint.textContent = ' (opens in a new tab)'
+    a.appendChild(hint)
+  }
+
+  function process (a) {
+    // Respect an explicit target the author or a widget already set: only add a
+    // new tab where none was requested. Still announce any link that ends up
+    // opening in a new tab, including ^-suffixed links that already carry it.
+    if (!a.hasAttribute('target')) {
+      a.setAttribute('target', '_blank')
+      ensureRel(a)
+    }
+    if (a.getAttribute('target') === '_blank') addHint(a)
+  }
+
   function run () {
-    // External, off-site links. The attribute-based :not() chain matches the
-    // doc.css selector; the feedback-section / autocomplete exclusions are
-    // applied in JS via closest() for broader browser support.
     const external = document.querySelectorAll(
-      '.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"]):not([href*="localhost"])'
+      '.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"])'
     )
     external.forEach(function (a) {
       if (a.closest('section.feedback-section') || a.closest('.aa-ItemIcon')) return
-      markNewTab(a)
+      process(a)
     })
 
     // On-site attachment/download links (the _attachments files).
-    document.querySelectorAll('.doc a.attachment[href]').forEach(markNewTab)
+    document.querySelectorAll('.doc a.attachment[href]').forEach(process)
   }
 
   if (document.readyState === 'loading') {

--- a/src/js/26-open-external-and-attachment-links.js
+++ b/src/js/26-open-external-and-attachment-links.js
@@ -5,18 +5,49 @@
   // new tab, and announce that to assistive tech, so readers don't silently
   // lose their place in the current page.
   //
-  // The external-link selector below MIRRORS the CSS rule that renders the
-  // external-link icon in src/css/doc.css (and src/css/doc-bump.css). Keep the
-  // two in sync: if you change the excluded hosts here, change them there too.
+  // A link counts as external when its resolved URL is http(s) and points at a
+  // host other than the page's own origin or the INTERNAL_HOSTS below. URLs
+  // are parsed rather than substring-matched, so a URL that merely *contains*
+  // an internal host name in its path or inside a longer hostname (for
+  // example https://evil.example/docs.redpanda.com) is still external.
+  //
+  // The external-link icon in src/css/doc.css (and src/css/doc-bump.css)
+  // approximates the same policy with substring selectors — the best CSS can
+  // do. Keep the host list below in sync with the hosts named there.
   // (localhost is intentionally NOT excluded: a link to a local app opens a
   // different origin, so a new tab keeps the docs page in place.)
   // Attachment links are matched by the `.attachment` class Antora adds to
   // `xref:...attachment$...` links; they get the download glyph via CSS.
 
-  const HINT_CLASS = 'doc-new-tab-hint'
+  // Hosts that count as on-site (same tab, no icon) wherever the page is
+  // served from. Subdomains match; substrings do not. The page's own
+  // host:port is always on-site, which also covers deploy previews.
+  var INTERNAL_HOSTS = ['docs.redpanda.com', 'netlify.app']
+
+  // Styled in src/css/doc.css (visually hidden); see also doc-bump.css.
+  var HINT_CLASS = 'doc-new-tab-hint'
+
+  function isInternal (url) {
+    if (url.host === window.location.host) return true
+    return INTERNAL_HOSTS.some(function (h) {
+      return url.hostname === h || url.hostname.endsWith('.' + h)
+    })
+  }
+
+  function isExternal (a) {
+    var url
+    try {
+      url = new URL(a.getAttribute('href'), window.location.href)
+    } catch (e) {
+      return false // unparseable href — leave the link alone
+    }
+    // Non-web schemes (mailto:, tel:, ...) are never external.
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+    return !isInternal(url)
+  }
 
   function ensureRel (a) {
-    const rel = (a.getAttribute('rel') || '').split(/\s+/).filter(Boolean)
+    var rel = (a.getAttribute('rel') || '').split(/\s+/).filter(Boolean)
     if (rel.indexOf('noopener') === -1) rel.push('noopener')
     a.setAttribute('rel', rel.join(' '))
   }
@@ -26,8 +57,8 @@
   // to assistive tech, so this is the only signal AT users get.
   function addHint (a) {
     if (a.querySelector('.' + HINT_CLASS)) return
-    const hint = document.createElement('span')
-    hint.className = 'visually-hidden ' + HINT_CLASS
+    var hint = document.createElement('span')
+    hint.className = HINT_CLASS
     hint.textContent = ' (opens in a new tab)'
     a.appendChild(hint)
   }
@@ -51,23 +82,29 @@
     return !!(a.closest('section.feedback-section') || a.closest('.aa-ItemIcon'))
   }
 
+  function qualifies (a) {
+    return isExternal(a) ||
+      a.classList.contains('attachment') ||
+      // An internal or relative ^-suffixed link still needs rel="noopener"
+      // and the screen-reader hint.
+      a.getAttribute('target') === '_blank'
+  }
+
   function run () {
-    // External off-site links -> open in a new tab.
-    document.querySelectorAll(
-      '.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not([href*="netlify.app"])'
-    ).forEach(function (a) { if (!isExcluded(a)) process(a) })
-
-    // On-site attachment/download links (the _attachments files).
-    document.querySelectorAll('.doc a.attachment[href]').forEach(process)
-
-    // Any remaining link that already opens in a new tab -- e.g. an internal or
-    // relative ^-suffixed link that the two passes above don't match -- still
-    // needs rel="noopener" and the screen-reader hint. process() is idempotent,
-    // so links already handled above are unaffected.
-    document.querySelectorAll('.doc a[target="_blank"]').forEach(function (a) {
-      if (!isExcluded(a)) process(a)
+    document.querySelectorAll('.doc a[href]').forEach(function (a) {
+      if (!isExcluded(a) && qualifies(a)) process(a)
     })
   }
+
+  // Doc content rendered after page load (for example previews inside the
+  // detached search overlay, which doc-bump.css gives the same icons) is
+  // missed by run(). This capturing listener applies the new-tab behavior
+  // just in time; process() is idempotent, so links run() already handled
+  // are unaffected.
+  document.addEventListener('click', function (e) {
+    var a = e.target && e.target.closest && e.target.closest('.doc a[href]')
+    if (a && !isExcluded(a) && qualifies(a)) process(a)
+  }, true)
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', run)


### PR DESCRIPTION
## What and why

External links should open in a new tab per the style guide, but today that relies on a per-link `^` suffix in AsciiDoc source — easy to miss, and impossible on auto-generated pages (~533 external links in the `k-*.adoc` reference pages have no `^`). There's no site-wide rule. Separately, on-site attachment/download links (for example the quickstart "file you downloaded" links) navigate the current tab and lose the reader's place.

This adds a site-wide rule so external **and** attachment links open in a new tab, gives attachment links a download glyph distinct from the external-link icon, and announces the new tab to assistive tech.

Jira: [DOC-2432](https://redpandadata.atlassian.net/browse/DOC-2432) (follow-up to DOC-2431 / docs PR #1915)

## Changes

- **`src/js/26-open-external-and-attachment-links.js`** — sets `target="_blank" rel="noopener"`, scoped to `.doc`, on:
  - external off-site links (mirrors the external-link icon selector in `doc.css`; excludes only `docs.redpanda.com` and `netlify.app`), and
  - `.doc a.attachment[href]` links;
  skipping any link that already has a `target`. It also appends a visually-hidden **"(opens in a new tab)"** phrase to every link that opens in a new tab (including `^`-suffixed links), since the icons are decorative CSS and invisible to assistive tech.
- **`src/img/download.svg`** — a tray+arrow download glyph, matched to the external-link icon's boxed style (single-color, recolored in dark mode via the shared `--external-link-filter`).
- **`src/css/doc.css` + `src/css/doc-bump.css`** — a `.doc a.attachment::after` rule that renders the download glyph, mirroring the external-link icon rule. Cross-reference comments tie the JS and CSS selectors together so they can't silently drift.
- **`preview-src/link-targets-test.adoc`** — a dev-only sample page that mirrors the quickstart's link types, so the preview demonstrates the behavior.

## localhost

`localhost` is treated like any other off-site host (external icon + new tab): a local-app link opens a different origin, so a new tab keeps the docs page in place. This also makes `localhost` consistent with `127.0.0.1`, which was never excluded from the icon rule.

## Coverage (audited across all content repos)

Every attachment/download link uses the same `xref:...attachment$...` syntax (Antora tags these with `class="attachment"`), so the selector covers 100% of them: 3 in the quickstart, 1 on the Console config page, 4 in redpanda-labs. Other "file" links (lab source files via `{content-url}`, release tarballs, artifacthub helm-values) are external and are handled by the external-link half of the rule. On-site API-reference and blog links (`/api/doc/...`, `/blog/...`) correctly stay same-tab.

## Behavior changes to be aware of

Because the UI bundle serves all doc sites, this also affects pre-existing links: 5 attachment links (1 Console config, 4 labs) gain the download glyph and open in a new tab, and `localhost` links now show the external icon and open in a new tab. Intended and consistent, but noted so it's not a surprise.

## How to preview

**Easiest — the Netlify deploy preview (automatic).** This PR gets a deploy preview that renders the docs-ui sample pages with this branch's bundle. The `link-targets-test.adoc` sample (which mirrors the quickstart's link types) is the quickest place to check:

- https://deploy-preview-417--docs-ui.netlify.app/link-targets-test.html

**Local docs-ui preview** (same sample pages, served from your machine):

```bash
cd docs-ui
LATEST_ENTERPRISE=26.2 npx gulp preview   # open http://localhost:5252/link-targets-test.html
```

`LATEST_ENTERPRISE` is just the latest-version label the UI shows; set it to the current latest (e.g. `26.2`) — the value doesn't affect this change. It's needed because otherwise `compile-partial.js` falls back to fetching that version from `raw.githubusercontent.com/redpanda-data/docs/main/antora.yml`, which now 404s/stalls (that repo is private) and can hang the build at `compileWidgets`. Setting it skips the fetch. (In CI/Netlify the fetch just 404s and the build continues, so the deploy preview is unaffected.)

**On the real quickstart, locally** (if you want the actual docs page rather than the sample):

```bash
# 1. Build this branch's bundle
cd docs-ui && LATEST_ENTERPRISE=26.2 npx gulp bundle        # → build/ui-bundle.zip

# 2. Build the docs site with that bundle instead of releases/latest, then serve it
cd ../docs && npx antora --ui-bundle-url ../docs-ui/build/ui-bundle.zip local-antora-playbook.yml
npx http-server build/site -p 4000                          # open .../get-started/quick-start/
```

Note: `local-antora-playbook.yml` aggregates all the content repos (now private) and every `v/*` branch, so a full build needs access to those and is slow. To build just the quickstart quickly, trim the playbook's `content.sources` to the single local source (`- url: .` / `branches: HEAD`) before running Antora.

On any of these, verify:
- External links (GitHub, Docker, Cloud) and the `localhost` links → external icon + open in a new tab.
- The `^`-suffixed link → opens in a new tab and still gets the hint (no double target).
- The `docs.redpanda.com` link → no icon, same tab.
- The attachment links → download glyph + new tab.
- With a screen reader (or by inspecting the DOM), each new-tab link carries a visually-hidden "(opens in a new tab)".
- Toggle dark mode: both glyphs recolor.

CI's `validate-build` check also lints and bundles the JS/CSS, confirming the change compiles.

## Relationship to DOC-2431

Once this ships, the manual `^` sweep in docs PR #1915 becomes redundant for external links (and this additionally covers the ~533 auto-generated links). We'll decide whether to keep or revert that sweep after seeing this.

## Rollout note

`docs-ui` is a separate bundle — this won't affect docs.redpanda.com until the bundle is released and the docs playbook bumps to the new version. (None of this appears in the page markdown/agent view; it's an HTML-only, human-browser affordance.)


[DOC-2432]: https://redpandadata.atlassian.net/browse/DOC-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ