### PR TITLE
DOC-2433, DOC-2441: Fix missing newline and content corruption in Bloblang YAML highlighting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,9 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+# These files carry an intentional trailing space after a YAML block-scalar
+# indicator ("mapping: | ") as a regression fixture for DOC-2433 - trimming
+# it silently weakens the test (see fixture-yaml-trailing-space)
+[{tests/bloblang-interactive/mini-playground-test.html,preview-src/bloblang-syntax-test.adoc}]
+trim_trailing_whitespace = false

--- a/preview-src/bloblang-syntax-test.adoc
+++ b/preview-src/bloblang-syntax-test.adoc
@@ -402,3 +402,48 @@ output:
   redpanda:
     topic: dad-jokes
 ----
+
+== Regression: Literal Block Scalars Are Not Rewritten (DOC-2441)
+
+https://redpandadata.atlassian.net/browse/DOC-2441[DOC-2441]: YAML performs
+no quote or escape processing on literal block scalars, so the highlighter
+must not either.
+
+**Check visually and with the copy button**: `join("\n")` and `join("\t")`
+must render (and copy) as two characters each - a backslash followed by a
+letter - never as a real line break or tab inside the string literal.
+
+[source,yaml]
+----
+pipeline:
+  processors:
+    - mapping: |
+        root.lines = this.values.join("\n")
+        root.tabbed = this.cols.join("\t")
+----
+
+**Check visually**: the first line's opening quote on `"prefix-"` and the
+last line's closing quote on `"-suffix"` must both render. They belong to
+two different string literals, and must not be stripped as if they enclosed
+the whole block.
+
+[source,yaml]
+----
+pipeline:
+  processors:
+    - mapping: |
+        "prefix-" + this.id + "-suffix"
+----
+
+**Check visually**: a trailing space after the `|` indicator must not glue
+the first Bloblang line onto the `mapping:` line (the space after `|` below
+is intentional).
+
+[source,yaml]
+----
+pipeline:
+  processors:
+    - mapping: | 
+        let doubled = this.value * 2
+        root.result = $doubled
+----

--- a/preview-src/bloblang-syntax-test.adoc
+++ b/preview-src/bloblang-syntax-test.adoc
@@ -368,3 +368,37 @@ spec:
             - name: DATABASE_URL
               value: "postgres://localhost:5432/mydb"
 ----
+
+== Regression: Block Scalar Indicator Must Stay on Its Own Line
+
+Reported against docs.redpanda.com as
+https://redpandadata.atlassian.net/browse/DOC-2433[DOC-2433]: this exact
+example (the Connect quickstart's producer pipeline) rendered as
+`mapping: |let jokes = [` on one line instead of `|` followed by a line
+break. Root cause was `extractBloblangFromBlock()` in
+`src/js/17-bloblang-yaml.js` trimming away the newline + indentation
+between the block-scalar indicator and the first line of Bloblang before
+`processMultilineMapping()` discarded the token's original content
+entirely.
+
+**Check visually**: `mapping: |` must end its own line, with `let jokes`
+starting the next line, indented — not glued onto the same line as `|`.
+If this collapses again, the leading-whitespace preservation in
+`processMultilineMapping()` has regressed.
+
+[source,yaml]
+----
+input:
+  generate:
+    interval: 5s
+    count: 0
+    mapping: |
+      let jokes = [
+        "Why don't scientists trust atoms? Because they make up everything!",
+        "I'm reading a book about anti-gravity. It's impossible to put down!"
+      ]
+      root = jokes.index(random_int(seed: timestamp_unix_nano(), max: jokes.length() - 1))
+output:
+  redpanda:
+    topic: dad-jokes
+----

--- a/preview-src/bloblang-syntax-test.adoc
+++ b/preview-src/bloblang-syntax-test.adoc
@@ -447,3 +447,16 @@ pipeline:
         let doubled = this.value * 2
         root.result = $doubled
 ----
+
+**Check visually and with the copy button**: quoted flow-scalar mappings must
+keep their quotes in the rendered output. The double-quoted example's escapes
+are processed once: `\"` renders as `"` and `\\n` renders as the two
+characters `\n` inside the string literal.
+
+[source,yaml]
+----
+pipeline:
+  processors:
+    - mapping: "root.joined = this.parts.join(\"\\n\")"
+    - mapping: 'root.id = this.user_id.string()'
+----

--- a/src/js/17-bloblang-yaml.js
+++ b/src/js/17-bloblang-yaml.js
@@ -121,25 +121,50 @@
   }
 
   /**
-   * Extract Bloblang code from a YAML literal block string
-   * Handles | and > block scalars
+   * Extract Bloblang code from a YAML scalar token's text.
+   *
+   * Returns { leading, code }:
+   * - leading: the whitespace trim() strips from the front of the token.
+   *   For block scalars this is the newline + indentation that separates
+   *   the | or > indicator from the first content line (the token can also
+   *   begin with spaces or tabs, because the [ \t]* after the indicator is
+   *   part of the scalar token in Prism's YAML grammar). It must be
+   *   restored when the token is re-rendered, or "mapping: |" collapses
+   *   onto the same line as the first Bloblang statement (DOC-2433).
+   * - code: the Bloblang source to tokenize.
+   *
+   * Block scalars (mapping: | ...) are literal source text: YAML performs
+   * no quote or escape processing on them, so neither does this function -
+   * rewriting \n inside them, or stripping a coincidental leading/trailing
+   * quote pair, corrupts the rendered and copied code (DOC-2441).
+   *
+   * Quoted flow scalars (mapping: "root = ...") are unwrapped and
+   * unescaped according to their quote style: double quotes process
+   * backslash escapes, single quotes only the '' escape.
    */
-  function extractBloblangFromBlock(tokenText) {
-    // Remove leading/trailing quotes if present
+  function extractBloblangFromBlock(tokenText, isBlockScalar) {
+    var leading = tokenText.slice(0, tokenText.length - tokenText.trimStart().length)
     var text = tokenText.trim()
-    if ((text.startsWith('"') && text.endsWith('"')) || (text.startsWith("'") && text.endsWith("'"))) {
-      text = text.slice(1, -1)
+
+    if (!isBlockScalar) {
+      var quote = text.charAt(0)
+      if ((quote === '"' || quote === "'") && text.length >= 2 && text.endsWith(quote)) {
+        text = text.slice(1, -1)
+        if (quote === '"') {
+          // Single pass so an escaped backslash can't feed a later rule
+          // (the old sequential replace chain turned \\n into \<newline>)
+          text = text.replace(/\\(.)/g, function (match, ch) {
+            if (ch === 'n') return '\n'
+            if (ch === 't') return '\t'
+            return ch
+          })
+        } else {
+          text = text.replace(/''/g, "'")
+        }
+      }
     }
 
-    // Handle escape sequences
-    text = text
-      .replace(/\\n/g, '\n')
-      .replace(/\\t/g, '\t')
-      .replace(/\\"/g, '"')
-      .replace(/\\'/g, "'")
-      .replace(/\\\\/g, '\\')
-
-    return text
+    return { leading: leading, code: text }
   }
 
   /**
@@ -304,17 +329,13 @@
    */
   function processMultilineMapping(token) {
     var rawText = token.textContent
-    var bloblangCode = extractBloblangFromBlock(rawText)
-
-    // extractBloblangFromBlock() trims rawText before tokenizing, which
-    // strips the newline + indentation that visually separates the YAML
-    // block-scalar indicator (| or >) from the first line of content.
-    // Capture it here so it can be restored below — otherwise the token's
-    // original whitespace is discarded when its innerHTML is replaced, and
-    // "mapping: |" collapses onto the same line as the first Bloblang
-    // statement (e.g. "mapping: |let jokes = [").
-    var leadingWhitespaceMatch = rawText.match(/^((?:\r?\n[ \t]*)+)/)
-    var leadingWhitespace = leadingWhitespaceMatch ? leadingWhitespaceMatch[1] : ''
+    // Prism's YAML grammar gives block scalars the "scalar" class ("string"
+    // is only an alias on them); a token with "string" alone is a quoted
+    // flow scalar, whose quotes/escapes YAML actually processes.
+    var isBlockScalar = token.classList.contains('scalar')
+    var extracted = extractBloblangFromBlock(rawText, isBlockScalar)
+    var bloblangCode = extracted.code
+    var leadingWhitespace = extracted.leading
 
     // Check for continuation content after this token
     var continuationNodes = collectLiteralBlockContinuation(token)
@@ -334,7 +355,11 @@
 
     var wrapper = document.createElement('span')
     wrapper.className = 'bloblang-embedded'
-    wrapper.innerHTML = escapeHtml(leadingWhitespace) + highlighted
+    // leadingWhitespace is whitespace-only (what trim() stripped), so it is
+    // HTML-inert and safe to concatenate unescaped. Asymmetry note: trailing
+    // whitespace on the scalar's last content line is still dropped by the
+    // trim - invisible in the render, observable only via the copy button.
+    wrapper.innerHTML = leadingWhitespace + highlighted
 
     token.innerHTML = ''
     token.appendChild(wrapper)

--- a/src/js/17-bloblang-yaml.js
+++ b/src/js/17-bloblang-yaml.js
@@ -303,7 +303,18 @@
    * Also handles continuation content after blank lines
    */
   function processMultilineMapping(token) {
-    var bloblangCode = extractBloblangFromBlock(token.textContent)
+    var rawText = token.textContent
+    var bloblangCode = extractBloblangFromBlock(rawText)
+
+    // extractBloblangFromBlock() trims rawText before tokenizing, which
+    // strips the newline + indentation that visually separates the YAML
+    // block-scalar indicator (| or >) from the first line of content.
+    // Capture it here so it can be restored below — otherwise the token's
+    // original whitespace is discarded when its innerHTML is replaced, and
+    // "mapping: |" collapses onto the same line as the first Bloblang
+    // statement (e.g. "mapping: |let jokes = [").
+    var leadingWhitespaceMatch = rawText.match(/^(\r?\n[ \t]*)/)
+    var leadingWhitespace = leadingWhitespaceMatch ? leadingWhitespaceMatch[1] : ''
 
     // Check for continuation content after this token
     var continuationNodes = collectLiteralBlockContinuation(token)
@@ -323,7 +334,7 @@
 
     var wrapper = document.createElement('span')
     wrapper.className = 'bloblang-embedded'
-    wrapper.innerHTML = highlighted
+    wrapper.innerHTML = escapeHtml(leadingWhitespace) + highlighted
 
     token.innerHTML = ''
     token.appendChild(wrapper)

--- a/src/js/17-bloblang-yaml.js
+++ b/src/js/17-bloblang-yaml.js
@@ -140,23 +140,30 @@
    *
    * Quoted flow scalars (mapping: "root = ...") are unwrapped and
    * unescaped according to their quote style: double quotes process
-   * backslash escapes, single quotes only the '' escape.
+   * backslash escapes, single quotes only the '' escape. The stripped
+   * quote character is returned so the caller can re-render it - the
+   * quotes are part of the YAML source the reader sees and copies.
    */
   function extractBloblangFromBlock(tokenText, isBlockScalar) {
     var leading = tokenText.slice(0, tokenText.length - tokenText.trimStart().length)
     var text = tokenText.trim()
+    var quote = null
 
     if (!isBlockScalar) {
-      var quote = text.charAt(0)
-      if ((quote === '"' || quote === "'") && text.length >= 2 && text.endsWith(quote)) {
+      var q = text.charAt(0)
+      if ((q === '"' || q === "'") && text.length >= 2 && text.endsWith(q)) {
+        quote = q
         text = text.slice(1, -1)
-        if (quote === '"') {
+        if (q === '"') {
           // Single pass so an escaped backslash can't feed a later rule
-          // (the old sequential replace chain turned \\n into \<newline>)
+          // (the old sequential replace chain turned \\n into \<newline>).
+          // Escapes this display code doesn't translate stay verbatim
+          // rather than losing their backslash (\r must not become r).
           text = text.replace(/\\(.)/g, function (match, ch) {
             if (ch === 'n') return '\n'
             if (ch === 't') return '\t'
-            return ch
+            if (ch === '"' || ch === "'" || ch === '\\' || ch === '/') return ch
+            return match
           })
         } else {
           text = text.replace(/''/g, "'")
@@ -164,7 +171,7 @@
       }
     }
 
-    return { leading: leading, code: text }
+    return { leading: leading, code: text, quote: quote }
   }
 
   /**
@@ -337,8 +344,11 @@
     var bloblangCode = extracted.code
     var leadingWhitespace = extracted.leading
 
-    // Check for continuation content after this token
-    var continuationNodes = collectLiteralBlockContinuation(token)
+    // Check for continuation content after this token. Only block scalars
+    // can have it (Prism splits them at blank lines); a quoted flow scalar
+    // is single-line by grammar, and collecting "continuation" for one
+    // swallows sibling keys that sit at or above the fallback base indent.
+    var continuationNodes = isBlockScalar ? collectLiteralBlockContinuation(token) : []
     var continuationText = extractTextFromNodes(continuationNodes)
 
     // Combine the token content with continuation
@@ -355,11 +365,15 @@
 
     var wrapper = document.createElement('span')
     wrapper.className = 'bloblang-embedded'
+    // Re-render the quotes stripped from a quoted flow scalar (same as
+    // processSingleLineCheck) so the reader still sees them and the copy
+    // button keeps them.
+    var quoteHtml = extracted.quote ? '<span class="token punctuation">' + extracted.quote + '</span>' : ''
     // leadingWhitespace is whitespace-only (what trim() stripped), so it is
     // HTML-inert and safe to concatenate unescaped. Asymmetry note: trailing
     // whitespace on the scalar's last content line is still dropped by the
     // trim - invisible in the render, observable only via the copy button.
-    wrapper.innerHTML = leadingWhitespace + highlighted
+    wrapper.innerHTML = leadingWhitespace + quoteHtml + highlighted + quoteHtml
 
     token.innerHTML = ''
     token.appendChild(wrapper)

--- a/src/js/17-bloblang-yaml.js
+++ b/src/js/17-bloblang-yaml.js
@@ -313,7 +313,7 @@
     // original whitespace is discarded when its innerHTML is replaced, and
     // "mapping: |" collapses onto the same line as the first Bloblang
     // statement (e.g. "mapping: |let jokes = [").
-    var leadingWhitespaceMatch = rawText.match(/^(\r?\n[ \t]*)/)
+    var leadingWhitespaceMatch = rawText.match(/^((?:\r?\n[ \t]*)+)/)
     var leadingWhitespace = leadingWhitespaceMatch ? leadingWhitespaceMatch[1] : ''
 
     // Check for continuation content after this token

--- a/tests/bloblang-interactive/mini-playground-test.html
+++ b/tests/bloblang-interactive/mini-playground-test.html
@@ -211,6 +211,36 @@ spec:
   processors:
     - mapping: "root = this.name.uppercase()"</code></pre>
         </div>
+
+        <!-- Fixture 12: double-quoted flow scalars WITH escape sequences,
+             pinning the unescape path: \" -> ", \\n -> \n, and untranslated
+             escapes like \r keep their backslash -->
+        <div class="listingblock" id="fixture-yaml-quoted-escapes">
+            <div class="source-toolbox"></div>
+            <pre class="highlight"><code class="language-yaml">pipeline:
+  processors:
+    - mapping: "root.joined = this.parts.join(\"\\n\")"
+    - mapping: "root.clean = this.text.replace_all(\"\r\", \"\")"</code></pre>
+        </div>
+
+        <!-- Fixture 13: single-quoted flow scalar (no backslash processing) -->
+        <div class="listingblock" id="fixture-yaml-single-quoted">
+            <div class="source-toolbox"></div>
+            <pre class="highlight"><code class="language-yaml">pipeline:
+  processors:
+    - mapping: 'root.id = this.user_id.string()'</code></pre>
+        </div>
+
+        <!-- Fixture 14: chomping indicator (|-). Prism's YAML grammar emits
+             no scalar token for these, so the highlighter must pass the
+             block through untouched (known limitation, not a regression) -->
+        <div class="listingblock" id="fixture-yaml-chomping">
+            <div class="source-toolbox"></div>
+            <pre class="highlight"><code class="language-yaml">pipeline:
+  processors:
+    - mapping: |-
+        root.value = this.count</code></pre>
+        </div>
     </div>
 
     <script>
@@ -623,7 +653,7 @@ spec:
 
             runner.test(
                 'Double-quoted flow scalar mapping still highlights',
-                'Quoted scalars keep their unwrap-and-unescape path (YAML does process those)',
+                'Quoted scalars keep their unwrap-and-unescape path (YAML does process those), and the quotes stay visible',
                 async () => {
                     const fixture = document.getElementById('fixture-yaml-quoted-mapping');
                     await sleep(200);
@@ -631,10 +661,76 @@ spec:
                     if (!code.querySelector('.bloblang-embedded')) {
                         throw new Error('Bloblang not detected in quoted mapping');
                     }
-                    if (!code.textContent.includes('root = this.name.uppercase()')) {
-                        throw new Error('Quoted mapping content corrupted: ' + JSON.stringify(code.textContent));
+                    if (!code.textContent.includes('mapping: "root = this.name.uppercase()"')) {
+                        throw new Error('Quoted mapping content or quotes corrupted: ' + JSON.stringify(code.textContent));
                     }
-                    return 'Quoted flow scalar unwrapped and highlighted';
+                    return 'Quoted flow scalar highlighted with its quotes intact';
+                }
+            );
+
+            runner.test(
+                'Double-quoted escapes are processed exactly once',
+                'DOC-2441: \\" becomes " and \\\\n becomes the two characters \\n - never a real newline',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml-quoted-escapes');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (!code.querySelector('.bloblang-embedded')) {
+                        throw new Error('Bloblang not detected in quoted mapping');
+                    }
+                    const text = code.textContent;
+                    // Source: "root.joined = this.parts.join(\"\\n\")"
+                    // Rendered: "root.joined = this.parts.join("\n")" with
+                    // \n as two characters inside real (unescaped) quotes
+                    if (!text.includes('join("\\n")')) {
+                        throw new Error('Escapes mishandled (want join("\\n") after unescaping): ' + JSON.stringify(text));
+                    }
+                    if (text.includes('join("\n')) {
+                        throw new Error('\\\\n became a real newline inside the string literal');
+                    }
+                    if (!text.includes('"root.joined')) {
+                        throw new Error('Outer quote of quoted mapping lost: ' + JSON.stringify(text));
+                    }
+                    // \r is a YAML escape this display code does not
+                    // translate: it must keep its backslash, not become "r"
+                    if (!text.includes('replace_all("\\r", "")')) {
+                        throw new Error('Untranslated escape \\r lost its backslash: ' + JSON.stringify(text));
+                    }
+                    return 'Double-quoted escape sequences processed exactly once';
+                }
+            );
+
+            runner.test(
+                'Single-quoted flow scalar mapping highlights',
+                'Single-quoted scalars unwrap without backslash processing, keeping their quotes visible',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml-single-quoted');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (!code.querySelector('.bloblang-embedded')) {
+                        throw new Error('Bloblang not detected in single-quoted mapping');
+                    }
+                    if (!code.textContent.includes("mapping: 'root.id = this.user_id.string()'")) {
+                        throw new Error('Single-quoted mapping corrupted: ' + JSON.stringify(code.textContent));
+                    }
+                    return 'Single-quoted flow scalar highlighted with its quotes intact';
+                }
+            );
+
+            runner.test(
+                'Chomping indicator (|-) passes through untouched',
+                'Prism emits no scalar token for |- blocks; the highlighter must leave them alone (known limitation)',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml-chomping');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (code.querySelector('.bloblang-embedded')) {
+                        throw new Error('|- block unexpectedly processed - grammar behavior changed, re-verify DOC-2433/DOC-2441 handling for it');
+                    }
+                    if (!code.textContent.includes('mapping: |-') || !code.textContent.includes('root.value = this.count')) {
+                        throw new Error('|- block content corrupted: ' + JSON.stringify(code.textContent));
+                    }
+                    return '|- block left untouched with content intact';
                 }
             );
 

--- a/tests/bloblang-interactive/mini-playground-test.html
+++ b/tests/bloblang-interactive/mini-playground-test.html
@@ -170,6 +170,47 @@ spec:
         - name: app
           image: myapp:latest</code></pre>
         </div>
+
+        <!-- Fixture 8 (DOC-2433): trailing space after the | indicator.
+             The space after "mapping: |" is INTENTIONAL - do not strip it. -->
+        <div class="listingblock" id="fixture-yaml-trailing-space">
+            <div class="source-toolbox"></div>
+            <pre class="highlight"><code class="language-yaml">pipeline:
+  processors:
+    - mapping: | 
+        let doubled = this.value * 2
+        root.result = $doubled</code></pre>
+        </div>
+
+        <!-- Fixture 9 (DOC-2441 issue 1): literal block scalar containing
+             backslash escapes that YAML does NOT process -->
+        <div class="listingblock" id="fixture-yaml-backslash">
+            <div class="source-toolbox"></div>
+            <pre class="highlight"><code class="language-yaml">pipeline:
+  processors:
+    - mapping: |
+        root.lines = this.values.join("\n")
+        root.tabbed = this.cols.join("\t")</code></pre>
+        </div>
+
+        <!-- Fixture 10 (DOC-2441 issue 2): block scalar that coincidentally
+             starts and ends with the same quote character -->
+        <div class="listingblock" id="fixture-yaml-quote-edge">
+            <div class="source-toolbox"></div>
+            <pre class="highlight"><code class="language-yaml">pipeline:
+  processors:
+    - mapping: |
+        "prefix-" + this.id + "-suffix"</code></pre>
+        </div>
+
+        <!-- Fixture 11: double-quoted flow scalar (quotes/escapes ARE
+             processed by YAML, so unwrapping remains correct here) -->
+        <div class="listingblock" id="fixture-yaml-quoted-mapping">
+            <div class="source-toolbox"></div>
+            <pre class="highlight"><code class="language-yaml">pipeline:
+  processors:
+    - mapping: "root = this.name.uppercase()"</code></pre>
+        </div>
     </div>
 
     <script>
@@ -499,6 +540,101 @@ spec:
                     }
 
                     return 'Regular YAML left unchanged';
+                }
+            );
+
+            runner.test(
+                'Block scalar newline and indentation survive re-rendering',
+                'DOC-2433 regression: "mapping: |" must keep its line break and the first line its indentation',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (!code.querySelector('.bloblang-embedded')) {
+                        throw new Error('Bloblang not detected in YAML mapping field');
+                    }
+                    if (!/mapping: \|\n {8}root\.processed/.test(code.textContent)) {
+                        throw new Error('Newline/indent after "mapping: |" lost: ' +
+                            JSON.stringify(code.textContent.match(/mapping: \|[^]{0,20}/)[0]));
+                    }
+                    return 'Newline and indentation preserved after block-scalar indicator';
+                }
+            );
+
+            runner.test(
+                'Trailing space after | does not collapse the first line',
+                'DOC-2433 regression (review finding): "mapping: | " with a trailing space must still break the line',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml-trailing-space');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (!code.querySelector('.bloblang-embedded')) {
+                        throw new Error('Bloblang not detected in YAML mapping field');
+                    }
+                    // The fixture intentionally has a space after "|"; if this
+                    // regex fails on "| \n", check the fixture was not
+                    // reformatted by an editor stripping trailing whitespace
+                    if (!/mapping: \| \n {8}let doubled/.test(code.textContent)) {
+                        throw new Error('Line break after "mapping: | " lost: ' +
+                            JSON.stringify(code.textContent.match(/mapping: \|[^]{0,20}/)[0]));
+                    }
+                    return 'Newline preserved despite trailing space after the indicator';
+                }
+            );
+
+            runner.test(
+                'Block scalar keeps literal backslash escapes',
+                'DOC-2441 issue 1: \\n inside a literal block scalar must stay two characters, not become a real newline',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml-backslash');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (!code.querySelector('.bloblang-embedded')) {
+                        throw new Error('Bloblang not detected in YAML mapping field');
+                    }
+                    const text = code.textContent;
+                    if (!text.includes('join("\\n")') || !text.includes('join("\\t")')) {
+                        throw new Error('Literal backslash escapes were rewritten: ' + JSON.stringify(text));
+                    }
+                    if (text.includes('join("\n")')) {
+                        throw new Error('\\n became a real newline inside the string literal');
+                    }
+                    return 'Backslash escapes preserved verbatim in block scalar';
+                }
+            );
+
+            runner.test(
+                'Block scalar keeps coincidental leading/trailing quotes',
+                'DOC-2441 issue 2: quotes belonging to two different string literals must not be stripped',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml-quote-edge');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (!code.querySelector('.bloblang-embedded')) {
+                        throw new Error('Bloblang not detected in YAML mapping field');
+                    }
+                    const text = code.textContent;
+                    if (!text.includes('"prefix-"') || !text.includes('"-suffix"')) {
+                        throw new Error('First/last quote was stripped: ' + JSON.stringify(text));
+                    }
+                    return 'Coincidental quote pair preserved in block scalar';
+                }
+            );
+
+            runner.test(
+                'Double-quoted flow scalar mapping still highlights',
+                'Quoted scalars keep their unwrap-and-unescape path (YAML does process those)',
+                async () => {
+                    const fixture = document.getElementById('fixture-yaml-quoted-mapping');
+                    await sleep(200);
+                    const code = fixture.querySelector('code');
+                    if (!code.querySelector('.bloblang-embedded')) {
+                        throw new Error('Bloblang not detected in quoted mapping');
+                    }
+                    if (!code.textContent.includes('root = this.name.uppercase()')) {
+                        throw new Error('Quoted mapping content corrupted: ' + JSON.stringify(code.textContent));
+                    }
+                    return 'Quoted flow scalar unwrapped and highlighted';
                 }
             );
 


### PR DESCRIPTION
## Summary

Fixes a rendering bug reported against docs.redpanda.com/cloud-data-platform (DOC-2433): the Connect quickstart's producer-pipeline YAML example renders as `mapping: |let jokes = [` on one line instead of:

```yaml
mapping: |
  let jokes = [
```

https://deploy-preview-419--docs-ui.netlify.app/bloblang-syntax-test#_regression_block_scalar_indicator_must_stay_on_its_own_line

**Not a docs-content bug** — the source YAML has always had the correct line break (confirmed via git history on the docs source repo). This highlighting extension is what's dropping it.

## Root cause

`extractBloblangFromBlock()` in `src/js/17-bloblang-yaml.js` trims a `mapping`/`mutation`/etc. token's raw text before tokenizing it as Bloblang, which strips the newline + indentation separating the YAML block-scalar indicator (`|`/`>`) from the first line of content. `processMultilineMapping()` then replaces the token's entire original content (`token.innerHTML = ''`) with only the tokenized (already-trimmed) Bloblang — so that leading newline is gone from the rendered output, not just from the tokenizer's input.

This is systemic, not a one-off: it affects every `mapping: |` (or `mutation`/`request_map`/etc.) block containing Bloblang, anywhere on the site.

## Fix

Capture the leading newline+indentation from the raw token text *before* it gets trimmed for tokenization, and prepend it (HTML-escaped) to the wrapper's `innerHTML` alongside the tokenized Bloblang content, so the original line break survives into the rendered output.

## Test plan

- [x] Reproduced the exact bug using the real, unmodified production code path (`prism-core.js` + `prism-bloblang.js` + this file) in a real headless Chrome instance via Puppeteer, using the same YAML example currently live on the Connect quickstart page.
- [x] Applied the fix and confirmed both `textContent` and a rendered screenshot show the correct line break restored.
- [x] `gulp lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR: DOC-2441

Per review follow-up, the two pre-existing corruption bugs in the same call chain ([DOC-2441](https://redpandadata.atlassian.net/browse/DOC-2441)) are fixed here rather than in a separate PR:

- Escape rewriting and quote-stripping now apply only to tokens Prism classified as quoted flow scalars; literal/folded block scalars pass through verbatim.
- The quoted-scalar path itself is hardened: untranslated escapes keep their backslash, stripped quotes are re-rendered (and copied), and quoted scalars no longer swallow sibling keys as block continuation.
- Regression tests for all of the above in tests/bloblang-interactive/ (21 tests; the DOC-2441 ones fail against the pre-fix code), plus visual sections on the bloblang-syntax-test preview page.

[DOC-2441]: https://redpandadata.atlassian.net/browse/DOC-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ