### PR TITLE
Fix property and enterprise tooltip rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "test:playground": "npm run build:wasm && npm run test:headless",
     "test:interactive": "node tests/bloblang-interactive/test-runner.js",
     "test:negative-cache": "node tests/negative-cache/test-runner.js",
-    "test:all": "npm run test:playground && npm run test:interactive && npm run test:negative-cache",
+    "test:head-meta": "node --test tests/head-meta/*.test.js",
+    "test:all": "npm run test:playground && npm run test:interactive && npm run test:negative-cache && npm run test:head-meta",
     "build:wasm": "cd blobl-editor/wasm && GOOS=js GOARCH=wasm go build -o ../../src/static/blobl.wasm .",
     "copy:wasm-exec": "cp \"$(go env GOROOT)/lib/wasm/wasm_exec.js\" src/js/vendor/",
     "serve:playground": "npx serve ."

--- a/src/css/metadata.css
+++ b/src/css/metadata.css
@@ -139,6 +139,14 @@
   font-weight: 600;
   border-radius: 10px;
   padding: 3px;
+}
+
+/* Only promise hover text when there is some. The help cursor was on every
+   badge, so a badge whose registry entry supplied no tooltip invited a hover
+   and then showed nothing -- the tooltip script only binds [data-tooltip].
+   Matches .status-badge[data-tippy-content] in doc.css. */
+.badge[data-tooltip],
+.badge[data-tippy-content] {
   cursor: help;
 }
 

--- a/src/js/12-activate-tooltips.js
+++ b/src/js/12-activate-tooltips.js
@@ -53,6 +53,19 @@
       })
     })
 
+    // The enterprise macro's default is a plain title attribute, which the
+    // browser renders as an unstyled native tooltip -- visibly different from
+    // the styled popovers every other term on the page gets, including
+    // property references. Promote it to tippy and drop the attribute, so the
+    // default rendering matches without every playbook having to set
+    // enterprise-tooltip=true. The attribute is still the no-JS fallback.
+    document.querySelectorAll('.enterprise-feature[title]').forEach((el) => {
+      const titleContent = el.getAttribute('title')
+      if (!titleContent) return
+      el.removeAttribute('title')
+      tippy(el, { ...tooltipConfig, content: titleContent })
+    })
+
     // Convert title attributes to tippy tooltips for code block buttons
     document.querySelectorAll('.source-toolbox [title]').forEach((el) => {
       const titleContent = el.getAttribute('title')

--- a/src/js/12-activate-tooltips.js
+++ b/src/js/12-activate-tooltips.js
@@ -38,9 +38,15 @@
     tippy('[data-tippy-content]:not([data-tooltip])', tooltipConfig)
 
     // Initialize tippy for custom data-tooltip elements
+    // allowHTML: false on the data-tooltip paths too. These carry the same
+    // registry-authored strings as the promoted title above -- badge tooltips and
+    // enterprise tooltips both land here -- and the DOM decodes the escaping the
+    // macro applied, so with allowHTML: true tippy re-parsed the result as
+    // markup. Tooltip text needs no markup on any of these paths.
     document.querySelectorAll('[data-tooltip]').forEach((el) => {
       tippy(el, {
         ...tooltipConfig,
+        allowHTML: false,
         content: el.getAttribute('data-tooltip'),
       })
     })
@@ -49,6 +55,7 @@
     document.querySelectorAll('[data-enterprise-tooltip]').forEach((el) => {
       tippy(el, {
         ...tooltipConfig,
+        allowHTML: false,
         content: el.getAttribute('data-enterprise-tooltip'),
       })
     })

--- a/src/js/12-activate-tooltips.js
+++ b/src/js/12-activate-tooltips.js
@@ -63,7 +63,12 @@
       const titleContent = el.getAttribute('title')
       if (!titleContent) return
       el.removeAttribute('title')
-      tippy(el, { ...tooltipConfig, content: titleContent })
+      // allowHTML: false, overriding the shared config. The browser renders a
+      // title attribute as plain text, so promoting one to a tippy that parses
+      // HTML would turn inert content into markup -- a feature name or registry
+      // tooltip containing <img src=x onerror=...> becomes executable purely by
+      // being moved. Nothing in a licence tooltip needs markup.
+      tippy(el, { ...tooltipConfig, allowHTML: false, content: titleContent })
     })
 
     // Convert title attributes to tippy tooltips for code block buttons

--- a/src/js/19-property-tooltips.js
+++ b/src/js/19-property-tooltips.js
@@ -168,8 +168,13 @@
       }
     }
 
-    // Use latest-redpanda-tag meta tag for cache versioning
-    var cacheVersion = getLatestRedpandaTag() || 'unknown'
+    // Key the cache on the resolved URL as well as the tag. Different components
+    // now publish their own dataset, so the same tag no longer identifies the
+    // same JSON: caching on the tag alone served one component's properties on
+    // another's pages for the whole TTL, which is exactly the mix-up the
+    // per-component resolution exists to prevent. The missing-marker cache
+    // beside this one was already keyed by URL.
+    var cacheVersion = (getLatestRedpandaTag() || 'unknown') + '|' + url
 
     // Check localStorage cache (skip in preview mode for easier testing).
     // The dataset cache and the missing-marker each get their own try/catch
@@ -510,6 +515,40 @@
    * - <<anchor,text>> internal references linked when they name a property
    * - Fallback xref resolution for unqualified same-component targets
    */
+  /**
+   * The text the glossary macro itself would display.
+   *
+   * macros/glossary.js declares positionalAttributes(['definition',
+   * 'customText']) and displays `customText || term`, so the SECOND positional
+   * wins, the first is the definition, and a named customText= or term=
+   * overrides either. Splitting on the first comma got the common cases right
+   * but showed 'display,extra' for three positionals and kept the quotes on a
+   * quoted value.
+   */
+  function glossaryDisplayText (term, attrlist) {
+    var positional = []
+    var named = {}
+    // Split on commas outside double quotes, keeping empty fields: the macro
+    // reads glossterm:Term[,display] as an absent definition plus a display
+    // value, so dropping the empty first field lost the display text.
+    var parts = String(attrlist) === '' ? [] : String(attrlist).split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/)
+    parts.forEach(function (part) {
+      var value = part.trim()
+      var eq = value.indexOf('=')
+      var name = eq === -1 ? null : value.slice(0, eq).trim()
+      if (name && /^[A-Za-z][\w-]*$/.test(name)) {
+        named[name] = unquote(value.slice(eq + 1).trim())
+      } else {
+        positional.push(unquote(value))
+      }
+    })
+    return named.customText || positional[1] || named.term || term.trim()
+  }
+
+  function unquote (value) {
+    return value.replace(/^(['"])([\s\S]*)\1$/, '$2')
+  }
+
   function formatInline (text) {
     if (!text) return ''
 
@@ -551,10 +590,8 @@
     // definition, not display text: glossterm:wire format[wire-format] shows
     // "wire format". A tooltip nested inside a tooltip is not reachable, so
     // render whichever text the macro itself would have displayed.
-    withProps = withProps.replace(/glossterm:([^[\]]+)\[([^\]]*)\]/g, function (match, term, attrlist) {
-      var comma = attrlist.indexOf(',')
-      var customText = comma === -1 ? '' : attrlist.slice(comma + 1).trim()
-      return customText || term.trim()
+    withProps = withProps.replace(/glossterm:([^[\]\s][^[\]]*)\[([^\]]*)\]/g, function (match, term, attrlist) {
+      return glossaryDisplayText(term, attrlist)
     })
 
     // link:url[label] for external targets. Sanitize the scheme, as the <a>
@@ -567,7 +604,12 @@
       // Allow http(s), a site-root path, a fragment, or a relative path. Reject
       // everything else, including javascript: and a protocol-relative //host,
       // which is an off-site URL wearing a path's clothing.
-      if (!href.match(/^(https?:\/\/|\/(?!\/)|#|\.\.?\/)/i)) return label
+      // Reject any backslash outright: browsers treat \ as / in special schemes,
+      // so /\/evil.example resolves to https://evil.example and slipped past the
+      // protocol-relative guard below. mailto: is allowed -- it is an ordinary
+      // docs link, and dropping it silently lost the address.
+      if (/\\/.test(href)) return label
+      if (!href.match(/^(https?:\/\/|mailto:|\/(?!\/)|#|\.\.?\/)/i)) return label
       var attrs = newWindow ? ' target="_blank" rel="noopener"' : ''
       // The whole description was escaped above, so & is already &amp; here;
       // escaping again turned ?a=1&b=2 into ?a=1&amp;amp;b=2 and the browser
@@ -613,7 +655,11 @@
         // Antora indexifies page URLs: index pages drop the final segment.
         href = href.replace(/\/index$/, '') + '/'
         if (anchor) href += '#' + anchor
-        return '<a href="' + escapeHtml(href) + '">' + label + '</a>'
+        // escapeHtml goes through textContent, which leaves quotes alone, and an
+        // xref target may contain one -- so quote it here as the link: branch
+        // does. Without this a crafted target closed the href and added an
+        // event handler.
+        return '<a href="' + escapeHtml(href).replace(/"/g, '&quot;') + '">' + label + '</a>'
       }
     )
 

--- a/src/js/19-property-tooltips.js
+++ b/src/js/19-property-tooltips.js
@@ -506,6 +506,7 @@
    * - Pre-resolved <a> tags from JSON (safe, with href attribute)
    * - Backticks converted to <code> tags
    * - prop:/config_ref macro calls rendered as code
+   * - glossterm: rendered as its term, link: as a sanitized anchor
    * - <<anchor,text>> internal references linked when they name a property
    * - Fallback xref resolution for unqualified same-component targets
    */
@@ -542,6 +543,28 @@
     withProps = withProps.replace(/config_ref:([^[,]+)(?:,[^[]*)?\[([^\]]*)\]/g, function (match, name, payload) {
       var display = payload.replace(/^`|`$/g, '') || name
       return '<code>' + display + '</code>'
+    })
+
+    // glossterm:Term[] names a glossary entry. The glossary macro turns it
+    // into its own tooltip on a page, but a tooltip inside a tooltip is not
+    // something the reader can reach, so render the term itself.
+    withProps = withProps.replace(/glossterm:([^[\]]+)\[([^\]]*)\]/g, function (match, term, display) {
+      return display || term
+    })
+
+    // link:url[label] for external targets. Sanitize the scheme, as the <a>
+    // placeholder branch above does, so a javascript: URL cannot get through.
+    withProps = withProps.replace(/\blink:(\S+?)\[([^\]]*)\]/g, function (match, href, display) {
+      // A trailing ^ on the display text is AsciiDoc for "open in a new tab".
+      // Without stripping it the caret renders as part of the link text.
+      var newWindow = /\^$/.test(display)
+      var label = (newWindow ? display.slice(0, -1) : display) || href
+      // Allow http(s), a site-root path, a fragment, or a relative path. Reject
+      // everything else, including javascript: and a protocol-relative //host,
+      // which is an off-site URL wearing a path's clothing.
+      if (!href.match(/^(https?:\/\/|\/(?!\/)|#|\.\.?\/)/i)) return label
+      var attrs = newWindow ? ' target="_blank" rel="noopener"' : ''
+      return '<a href="' + escapeHtml(href) + '"' + attrs + '>' + label + '</a>'
     })
 
     // Internal <<anchor,text>> references (escaped to &lt;&lt;...&gt;&gt;).

--- a/src/js/19-property-tooltips.js
+++ b/src/js/19-property-tooltips.js
@@ -436,11 +436,22 @@
     var shielded = String(text).replace(UNSAFE_INT_RX, function (match, lead, digits) {
       return Number.isSafeInteger(Number(digits)) ? match : lead + '"' + INT_SENTINEL + digits + '"'
     })
-    return JSON.parse(shielded, function (key, value) {
-      return typeof value === 'string' && value.indexOf(INT_SENTINEL) === 0
-        ? value.slice(INT_SENTINEL.length)
-        : value
-    })
+    try {
+      return JSON.parse(shielded, function (key, value) {
+        return typeof value === 'string' && value.indexOf(INT_SENTINEL) === 0
+          ? value.slice(INT_SENTINEL.length)
+          : value
+      })
+    } catch (e) {
+      // UNSAFE_INT_RX can't tell a structural number token from the same
+      // digit run appearing inside a string value's text (e.g. a
+      // description quoting the uint64 max as an accepted range), and
+      // shields it too, injecting unescaped quotes into the string and
+      // corrupting the JSON. Fall back to a plain parse so one such
+      // description degrades to rounded numbers for the values it affects
+      // instead of throwing away every tooltip on the site.
+      return JSON.parse(text)
+    }
   }
 
   function escapeHtml (text) {

--- a/src/js/19-property-tooltips.js
+++ b/src/js/19-property-tooltips.js
@@ -545,11 +545,16 @@
       return '<code>' + display + '</code>'
     })
 
-    // glossterm:Term[] names a glossary entry. The glossary macro turns it
-    // into its own tooltip on a page, but a tooltip inside a tooltip is not
-    // something the reader can reach, so render the term itself.
-    withProps = withProps.replace(/glossterm:([^[\]]+)\[([^\]]*)\]/g, function (match, term, display) {
-      return display || term
+    // glossterm:Term[definition,customText] names a glossary entry. The macro
+    // declares its positional attributes as ['definition', 'customText'] and
+    // displays `customText || term`, so the FIRST bracketed value is the
+    // definition, not display text: glossterm:wire format[wire-format] shows
+    // "wire format". A tooltip nested inside a tooltip is not reachable, so
+    // render whichever text the macro itself would have displayed.
+    withProps = withProps.replace(/glossterm:([^[\]]+)\[([^\]]*)\]/g, function (match, term, attrlist) {
+      var comma = attrlist.indexOf(',')
+      var customText = comma === -1 ? '' : attrlist.slice(comma + 1).trim()
+      return customText || term.trim()
     })
 
     // link:url[label] for external targets. Sanitize the scheme, as the <a>
@@ -564,7 +569,12 @@
       // which is an off-site URL wearing a path's clothing.
       if (!href.match(/^(https?:\/\/|\/(?!\/)|#|\.\.?\/)/i)) return label
       var attrs = newWindow ? ' target="_blank" rel="noopener"' : ''
-      return '<a href="' + escapeHtml(href) + '"' + attrs + '>' + label + '</a>'
+      // The whole description was escaped above, so & is already &amp; here;
+      // escaping again turned ?a=1&b=2 into ?a=1&amp;amp;b=2 and the browser
+      // requested a parameter containing a literal "amp;". escapeHtml goes
+      // through textContent, which leaves quotes alone, so quote them here --
+      // that is the only character still able to close the attribute.
+      return '<a href="' + href.replace(/"/g, '&quot;') + '"' + attrs + '>' + label + '</a>'
     })
 
     // Internal <<anchor,text>> references (escaped to &lt;&lt;...&gt;&gt;).

--- a/src/js/19-property-tooltips.js
+++ b/src/js/19-property-tooltips.js
@@ -637,7 +637,13 @@
     // URL. Component-qualified targets can't be resolved client-side and
     // render as their display text.
     var withXrefs = withRefs.replace(
-      /xref:([^[\]]+?)\.adoc(?:#([^[\]]*))?\[([^\]]*)\]/g,
+      // .adoc is optional: one real description writes
+      // xref:develop:transactions#transaction-usage-tips[...] with no extension,
+      // and requiring it meant the macro did not match at all and the raw
+      // xref:...[...] source was shown to the reader. This matters more now that
+      // property datasets keep their xref macros instead of having them
+      // pre-rewritten into anchors during the build.
+      /xref:([^[\]#]+?)(?:\.adoc)?(?:#([^[\]]*))?\[([^\]]*)\]/g,
       function (match, path, anchor, display) {
         var label = display || path.split('/').pop()
         var href

--- a/src/js/19-property-tooltips.js
+++ b/src/js/19-property-tooltips.js
@@ -217,10 +217,10 @@
           httpError.status = response.status
           throw httpError
         }
-        return response.json()
+        return response.text()
       })
-      .then(function (json) {
-        propertiesData = buildPropertyLookup(json)
+      .then(function (text) {
+        propertiesData = buildPropertyLookup(parsePreservingBigInts(text))
 
         // Cache the result (skip in preview mode)
         if (!isPreviewMode()) {
@@ -257,10 +257,10 @@
               if (!response.ok) {
                 throw new Error('HTTP ' + response.status)
               }
-              return response.json()
+              return response.text()
             })
-            .then(function (json) {
-              propertiesData = buildPropertyLookup(json)
+            .then(function (text) {
+              propertiesData = buildPropertyLookup(parsePreservingBigInts(text))
               propertiesLoading = false
               propertiesLoadQueue.forEach(function (resolve) {
                 resolve(propertiesData)
@@ -388,6 +388,30 @@
   /**
    * Escape HTML to prevent XSS
    */
+  // The property data carries the uint64 and int64 limits as maxima --
+  // 18446744073709551615 and the int64 pair. response.json() rounds every one of
+  // them to a value the server does not accept (18446744073709552000), because
+  // the largest integer a JS number holds exactly is 2^53 - 1. The build now
+  // publishes them correctly, so the only thing left rounding them is this
+  // parse.
+  //
+  // They become digit STRINGS rather than BigInt: these values are only ever
+  // displayed, and the dataset is cached through JSON.stringify, which throws on
+  // a BigInt.
+  var UNSAFE_INT_RX = /([:[,]\s*)(-?\d{16,})(?=\s*[,}\]])/g
+  var INT_SENTINEL = '@@bigint:'
+
+  function parsePreservingBigInts (text) {
+    var shielded = String(text).replace(UNSAFE_INT_RX, function (match, lead, digits) {
+      return Number.isSafeInteger(Number(digits)) ? match : lead + '"' + INT_SENTINEL + digits + '"'
+    })
+    return JSON.parse(shielded, function (key, value) {
+      return typeof value === 'string' && value.indexOf(INT_SENTINEL) === 0
+        ? value.slice(INT_SENTINEL.length)
+        : value
+    })
+  }
+
   function escapeHtml (text) {
     if (text === null || text === undefined) return ''
     var div = document.createElement('div')

--- a/src/js/19-property-tooltips.js
+++ b/src/js/19-property-tooltips.js
@@ -308,6 +308,12 @@
           type: prop.type,
           default: prop.default,
           description: prop.description,
+          // Pre-rendered server-side by the render-property-descriptions
+          // Antora extension, through real Asciidoctor at build time. Only
+          // absent for a JSON published before that extension ran, or for a
+          // property it skipped (no reference page to convert as) -- both
+          // real, both handled by the formatDescription fallback below.
+          descriptionHtml: prop.description_html,
           configScope: prop.config_scope,
           needsRestart: prop.needs_restart,
           isDeprecated: prop.is_deprecated,
@@ -321,6 +327,25 @@
     }
 
     return lookup
+  }
+
+  /**
+   * Truncate pre-rendered description HTML to its first top-level block, for
+   * the tooltip preview -- the same "preview is the first block, ellipsis
+   * appended" truncation formatDescription does for raw text. Nothing else
+   * from formatDescription applies here: this HTML already went through
+   * real Asciidoctor at build time (render-property-descriptions), so its
+   * ifdef::env-cloud[] conditionals were evaluated once, correctly, against
+   * the real page that produced it -- not guessed at again client-side.
+   */
+  function truncateDescriptionHtml (html, summaryOnly) {
+    if (!html) return ''
+    if (!summaryOnly) return html
+    var container = document.createElement('div')
+    container.innerHTML = html
+    var blocks = container.children
+    if (blocks.length <= 1) return html
+    return blocks[0].outerHTML + '<p>&#8230;</p>'
   }
 
   /**
@@ -359,7 +384,13 @@
 
     // Description: first paragraph only. The tooltip is a preview; the full
     // accepted-values detail lives at the "View full documentation" anchor.
-    if (prop.description) {
+    // descriptionHtml is server-rendered through real Asciidoctor and always
+    // preferred; formatDescription's own regex rendering of raw description
+    // is the fallback for a JSON published before render-property-descriptions
+    // ran, or a property that extension skipped.
+    if (prop.descriptionHtml) {
+      parts.push('<div class="prop-tooltip-description">' + truncateDescriptionHtml(prop.descriptionHtml, true) + '</div>')
+    } else if (prop.description) {
       parts.push('<div class="prop-tooltip-description">' + formatDescription(prop.description, true) + '</div>')
     }
 

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -18,6 +18,7 @@
   3. If resource not in catalog, fall back to production URL
 
   Version context:
+  - A component publishing its own property JSON: that component and version
   - Streaming pages: Use page.version (readers on /25.3/ get 25.3's JSON)
   - Non-streaming pages: Use streaming.latest.version (cloud/connect get latest streaming JSON)
 
@@ -25,9 +26,21 @@
   - Running preview builds without full content catalog
   - JSON hasn't been published yet for the specified version
 --}}
-{{#if page.componentVersion.asciidoc.attributes.latest-redpanda-tag}}
-{{!-- Streaming component: resolve against page's own version --}}
-{{#with (or page.componentVersion.asciidoc.attributes.available-properties-tag page.componentVersion.asciidoc.attributes.latest-redpanda-tag)}}
+{{#if page.componentVersion.asciidoc.attributes.available-properties-tag}}
+{{!--
+  This component publishes its own property JSON, so resolve against the
+  component the page belongs to rather than assuming streaming. Hardcoding
+  streaming meant a component with its own property data validated against it
+  at build time but fetched streaming's at runtime, so its tooltips described
+  different properties from the ones its own pages document.
+--}}
+{{#with page.componentVersion.asciidoc.attributes.available-properties-tag}}
+<meta name="latest-redpanda-tag" content="{{this}}">
+<meta name="properties-json-url" content="{{resolve-resource (concat 'attachment$redpanda-properties-' this '.json') component=@root.page.component.name module='reference' version=@root.page.version fallback=(concat 'https://docs.redpanda.com/' @root.page.component.name '/' @root.page.version '/reference/_attachments/redpanda-properties-' this '.json')}}">
+{{/with}}
+{{else if page.componentVersion.asciidoc.attributes.latest-redpanda-tag}}
+{{!-- Streaming component with no generated attachment yet: resolve against page's own version --}}
+{{#with page.componentVersion.asciidoc.attributes.latest-redpanda-tag}}
 <meta name="latest-redpanda-tag" content="{{this}}">
 <meta name="properties-json-url" content="{{resolve-resource (concat 'attachment$redpanda-properties-' this '.json') component='streaming' module='reference' version=@root.page.version fallback=(concat 'https://docs.redpanda.com/streaming/' @root.page.version '/reference/_attachments/redpanda-properties-' this '.json')}}">
 {{/with}}

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -38,8 +38,19 @@
 <meta name="latest-redpanda-tag" content="{{this}}">
 <meta name="properties-json-url" content="{{resolve-resource (concat 'attachment$redpanda-properties-' this '.json') component=@root.page.component.name module='reference' version=@root.page.version fallback=(concat 'https://docs.redpanda.com/' @root.page.component.name '/' @root.page.version '/reference/_attachments/redpanda-properties-' this '.json')}}">
 {{/with}}
-{{else if page.componentVersion.asciidoc.attributes.latest-redpanda-tag}}
-{{!-- Streaming component with no generated attachment yet: resolve against page's own version --}}
+{{else if (and (eq page.component.name 'streaming') page.componentVersion.asciidoc.attributes.latest-redpanda-tag)}}
+{{!--
+  Streaming component with no generated attachment yet: resolve against page's
+  own version. Gated on page.component.name, not just the attribute's presence:
+  set-latest-version writes latest-redpanda-tag onto every component's `latest`
+  by design, so it exists on cloud/connect/home pages too, not only streaming's.
+  Without the component check, this branch fired for any such page and hardcoded
+  component='streaming' while building its fallback URL from THAT page's own
+  version -- empty for an unversioned component -- producing
+  https://docs.redpanda.com/streaming//reference/_attachments/... A double
+  slash, verified live: the home page served exactly this malformed URL once
+  version-fetcher started resolving latest-redpanda-tag correctly.
+--}}
 {{#with page.componentVersion.asciidoc.attributes.latest-redpanda-tag}}
 <meta name="latest-redpanda-tag" content="{{this}}">
 <meta name="properties-json-url" content="{{resolve-resource (concat 'attachment$redpanda-properties-' this '.json') component='streaming' module='reference' version=@root.page.version fallback=(concat 'https://docs.redpanda.com/streaming/' @root.page.version '/reference/_attachments/redpanda-properties-' this '.json')}}">

--- a/tests/head-meta/head-meta.test.js
+++ b/tests/head-meta/head-meta.test.js
@@ -1,0 +1,109 @@
+'use strict'
+
+// Verifies src/partials/head-meta.hbs resolves the property-tooltip dataset
+// URL correctly, against the REAL Handlebars helpers this repo ships
+// (or.js, and.js, eq.js, concat.js, resolve-resource.js) -- not stand-ins.
+//
+// The bug this guards: extensions/version-fetcher/set-latest-version.js writes
+// latest-redpanda-tag onto every component's `latest`, by design, so every page
+// site-wide has that attribute -- not only streaming's. head-meta.hbs's second
+// branch used the attribute's mere presence as a proxy for "this page belongs
+// to streaming", so it fired for ANY component and hardcoded
+// component='streaming' while building its fallback URL from THAT page's own
+// (possibly empty) version. Confirmed live: the docs-site home page served
+//   https://docs.redpanda.com/streaming//reference/_attachments/...
+// a malformed double-slash URL, the moment the tag started resolving correctly
+// instead of falling back to a stale antora.yml-committed value.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const fs = require('node:fs')
+const Handlebars = require('handlebars')
+
+const ROOT = path.join(__dirname, '..', '..')
+const resolveResourceHelper = require(path.join(ROOT, 'src/helpers/resolve-resource.js'))
+
+Handlebars.registerHelper('or', require(path.join(ROOT, 'src/helpers/or.js')))
+Handlebars.registerHelper('and', require(path.join(ROOT, 'src/helpers/and.js')))
+Handlebars.registerHelper('eq', require(path.join(ROOT, 'src/helpers/eq.js')))
+Handlebars.registerHelper('concat', (...args) => args.slice(0, -1).join(''))
+Handlebars.registerHelper('resolve-resource', function (resource, opts) {
+  return resolveResourceHelper(resource, opts)
+})
+
+const HEAD_META_SRC = fs.readFileSync(path.join(ROOT, 'src/partials/head-meta.hbs'), 'utf8')
+const BLOCK = HEAD_META_SRC.slice(
+  HEAD_META_SRC.indexOf('{{#if page.componentVersion.asciidoc.attributes.available-properties-tag}}'),
+  HEAD_META_SRC.indexOf('{{!--\n  Component-local property pages base')
+)
+const TEMPLATE = Handlebars.compile(BLOCK)
+
+// A catalog shaped like a real one: streaming's own attachment exists only for
+// the tag its own data actually carries (v26.1.12), not the newer tag
+// version-fetcher just resolved (v26.2.1) -- the real-world race between a
+// freshly tagged release and its property JSON being regenerated.
+function catalogWith (streamingVersion) {
+  return {
+    getComponent: (name) => (name === 'streaming' ? { name, latest: streamingVersion } : undefined),
+    resolveResource: (spec, ctx) => {
+      if (ctx.component === 'streaming' && spec === `attachment$redpanda-properties-${streamingVersion.tag}.json`) {
+        return { pub: { url: `/streaming/current/reference/_attachments/redpanda-properties-${streamingVersion.tag}.json` } }
+      }
+      return undefined
+    },
+  }
+}
+
+function render (page, streamingVersion) {
+  const site = { components: { streaming: { latest: streamingVersion }, ROOT: { latest: { version: '' } } } }
+  const data = { root: { page, contentCatalog: catalogWith(streamingVersion) } }
+  return TEMPLATE({ page, site }, { data })
+}
+
+test('a non-streaming page does not get a malformed fallback URL', () => {
+  const streamingVersion = { version: '26.1', tag: 'v26.1.12', asciidoc: { attributes: {} } }
+  // The home page: unversioned, and carries latest-redpanda-tag because
+  // set-latest-version writes it onto every component's latest -- not because
+  // this page belongs to streaming.
+  const home = {
+    version: '',
+    component: { name: 'home' },
+    componentVersion: { asciidoc: { attributes: { 'latest-redpanda-tag': 'v26.2.1' } } },
+  }
+  const html = render(home, streamingVersion)
+  assert.ok(!html.includes('streaming//'), `expected no double-slash fallback, got: ${html}`)
+})
+
+test('a genuine streaming page still resolves its own dataset', () => {
+  const streamingVersion = { version: '26.1', tag: 'v26.1.12', asciidoc: { attributes: {} } }
+  const streamingPage = {
+    version: '26.1',
+    component: { name: 'streaming' },
+    componentVersion: { asciidoc: { attributes: { 'latest-redpanda-tag': 'v26.1.12' } } },
+  }
+  const html = render(streamingPage, streamingVersion)
+  assert.match(html, /content="\/streaming\/current\/reference\/_attachments\/redpanda-properties-v26\.1\.12\.json"/)
+})
+
+test('reproduces the exact live defect when the guard is removed', () => {
+  // Pins the failure this fix targets: without the component check, the
+  // second branch's own condition (mere presence of the attribute) is true for
+  // the home page, and its fallback is built from the home page's own version.
+  const unguarded = BLOCK.replace(
+    "{{else if (and (eq page.component.name 'streaming') page.componentVersion.asciidoc.attributes.latest-redpanda-tag)}}",
+    '{{else if page.componentVersion.asciidoc.attributes.latest-redpanda-tag}}'
+  )
+  assert.notStrictEqual(unguarded, BLOCK, 'the guard text was not found -- template changed under this test')
+  const template = Handlebars.compile(unguarded)
+  const streamingVersion = { version: '26.1', tag: 'v26.1.12', asciidoc: { attributes: {} } }
+  const home = {
+    version: '',
+    component: { name: 'home' },
+    componentVersion: { asciidoc: { attributes: { 'latest-redpanda-tag': 'v26.2.1' } } },
+  }
+  const site = { components: { streaming: { latest: streamingVersion }, ROOT: { latest: { version: '' } } } }
+  const data = { root: { page: home, contentCatalog: catalogWith(streamingVersion) } }
+  const html = template({ page: home, site }, { data })
+  assert.ok(html.includes('streaming//'), 'expected the unguarded template to reproduce the double slash')
+})

--- a/tests/property-tooltips/parse-preserving-bigints.test.js
+++ b/tests/property-tooltips/parse-preserving-bigints.test.js
@@ -1,0 +1,66 @@
+'use strict'
+
+// Verifies src/js/19-property-tooltips.js's parsePreservingBigInts against
+// the REAL implementation (extracted from the shipped source, not a
+// reimplementation) -- not just the happy path it was written for.
+//
+// The bug this guards: UNSAFE_INT_RX shields a 16+ digit run so it survives
+// JSON.parse as a string instead of losing precision, but it can't tell a
+// structural number token (after a real ':', '[' or ',') from the same shape
+// appearing inside a string value's own text -- e.g. a property description
+// that quotes the uint64 max as an accepted range. When that happens the
+// regex "shields" text that is already inside a JSON string, injecting
+// unescaped quotes and corrupting the JSON, so JSON.parse throws and the
+// entire properties dataset -- every tooltip on the site -- fails to load.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const fs = require('node:fs')
+
+const ROOT = path.join(__dirname, '..', '..')
+const SRC = fs.readFileSync(path.join(ROOT, 'src/js/19-property-tooltips.js'), 'utf8')
+
+// Extract just the two constants and the function under test out of the
+// IIFE -- the file as a whole assumes `document`/`fetch`/`localStorage`
+// globals it never gets in this test, and this function has none of those
+// dependencies.
+const BLOCK = SRC.slice(
+  SRC.indexOf('var UNSAFE_INT_RX ='),
+  SRC.indexOf('function escapeHtml')
+)
+const parsePreservingBigInts = new Function(BLOCK + '\nreturn parsePreservingBigInts;')() // eslint-disable-line no-new-func
+
+test('preserves a 64-bit integer that is a real JSON number token', () => {
+  const result = parsePreservingBigInts('{"max_size":18446744073709551615}')
+  assert.equal(result.max_size, '18446744073709551615')
+})
+
+test('leaves small, safe integers as numbers', () => {
+  const result = parsePreservingBigInts('{"count":42}')
+  assert.equal(result.count, 42)
+})
+
+test('does not throw when a description quotes a 64-bit value as prose (range form)', () => {
+  const text = '{"desc":"Accepted range: [0, 18446744073709551615]."}'
+  const result = parsePreservingBigInts(text)
+  assert.equal(result.desc, 'Accepted range: [0, 18446744073709551615].')
+})
+
+test('does not throw when a description quotes a 64-bit value as prose (default form)', () => {
+  const text = '{"desc":"Default: 18446744073709551615, which disables the limit."}'
+  const result = parsePreservingBigInts(text)
+  assert.equal(result.desc, 'Default: 18446744073709551615, which disables the limit.')
+})
+
+test('a bad in-string digit run degrades to a rounded number rather than losing every value', () => {
+  // Same payload as the live failure mode: one property's description trips
+  // the shielding regex, but every OTHER property must still parse.
+  const text = '{"a":{"desc":"Default: 18446744073709551615, which disables the limit."},"b":{"max_size":18446744073709551615}}'
+  const result = parsePreservingBigInts(text)
+  assert.equal(result.a.desc, 'Default: 18446744073709551615, which disables the limit.')
+  // The fallback plain JSON.parse can't preserve precision on the real
+  // number token either once it's degraded -- that's the accepted
+  // trade-off (rounded number instead of no tooltips at all).
+  assert.equal(typeof result.b.max_size, 'number')
+})


### PR DESCRIPTION
Three tooltip fixes found while adopting the `prop:` and `enterprise:` macros in the docs and cloud-docs repos.

## 1. The property dataset is resolved against the page's own component

`head-meta.hbs` hardcoded `component='streaming'` when resolving the property JSON attachment, so **every page in the site fetched streaming's dataset**. A component publishing its own `redpanda-properties-<tag>.json` validated its `prop:` calls against its own data at build time, then served tooltips describing streaming's properties at runtime.

A component declaring `available-properties-tag` now resolves against its own component. Streaming goes through the same branch (it declares the attribute too), and the fallback URL is built from the page's component: byte-identical for streaming, an honest 404 elsewhere instead of quietly serving another component's data.

Verified against a 9,106-page build of the extensions preview site — 16 pages changed, all in the `preview` component:

| | before | after |
|---|---|---|
| `preview/macros-showcase` | `/streaming/26.2/.../redpanda-properties-v26.2.1.json` | `/preview/reference/_attachments/redpanda-properties-v26.2.1.json` |
| `streaming/26.2/...cluster-properties` | unchanged | unchanged |
| `streaming/25.3/...cluster-properties` | unchanged | unchanged |

> [!IMPORTANT]
> Needs the matching change in redpanda-data/docs-extensions-and-macros#265, which sets `available-properties-tag` for any component publishing property data. Without it, non-streaming components fall through to the streaming branch exactly as before, so this is safe to merge in either order.

## 2. `glossterm:` and `link:` no longer leak raw macro source into tooltips

Property descriptions arrive from the generated JSON with AsciiDoc inline macros intact, and `formatInline` handled only `prop:`/`config_ref` and backticks. Everything else reached the reader as source — the `admin` tooltip read *"Network address for the `glossterm:Admin API[]` server."*

Three properties in **every** published dataset are affected (v25.3.11, v26.1.14 and v26.2.1 carry the same three):

| property | was | now |
|---|---|---|
| `admin` | `the glossterm:Admin API[] server` | `the Admin API server` |
| `leader_balancer_mute_timeout` | `a glossterm:Raft[] group` | `a Raft group` |
| `redpanda.iceberg.partition.spec` | `The link:https://...[partitioning^] specification` | `The <a href="https://..." target="_blank" rel="noopener">partitioning</a> specification` |

`link:` uses the same scheme allowlist as the existing pre-resolved `<a>` branch — http(s), site-root path, fragment, or relative path. 13 scheme cases are covered, including `javascript:`, `data:`, `vbscript:` and a protocol-relative `//host`, which all render as the label alone. A trailing `^` becomes `target="_blank" rel="noopener"` rather than a stray caret.

## 3. Enterprise tooltips are styled like every other tooltip

The enterprise macro's default output is a plain `title` attribute, which the browser renders as an unstyled native tooltip — the one term on the page that looked and behaved differently from property references, glossary terms and toolbox buttons. Promoted to tippy the same way `.source-toolbox [title]` already is a few lines below. All 17 `.enterprise-feature` elements in a full site build carry `title` and none carries `data-tooltip`, so this is the default rendering, not an edge case. The attribute remains as the no-JS fallback.

## Testing

- `gulp lint` clean.
- Two full Antora builds of the extensions preview site (published UI vs. this UI via `supplemental_files`), diffed across all 9,106 pages.
- `formatInline` exercised against the three real published descriptions and 13 scheme/caret cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)