### PR TITLE
Sign-in modal: register via Auth0 native signup, not Cloud's wizard

### DIFF
--- a/src/js/26-docs-account.js
+++ b/src/js/26-docs-account.js
@@ -21,7 +21,6 @@
   var signoutLink = container.querySelector('[data-account-signout]')
   var modal = container.querySelector('[data-signin-modal]')
   var modalCta = container.querySelector('[data-signin-modal-continue]')
-  var modalSignup = container.querySelector('[data-signin-modal-signup]')
 
   var CACHE_KEY = 'docs-account-me'
 
@@ -44,7 +43,11 @@
   }
 
   function returnTo () {
-    return encodeURIComponent(window.location.pathname + window.location.search)
+    // Include the hash: without it, a user reading a specific #section-anchor
+    // who signs in gets bounced back to the top of the page instead of where
+    // they were. docs-site's safeReturnTo() already accepts a path+query+hash
+    // string as-is (it only checks scheme/shape, not content).
+    return encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)
   }
 
   // Feature modal shown before sending the user to /login.
@@ -198,10 +201,6 @@
     // and go straight to Auth0. The bare signinLink href (middle-click, or no
     // modal markup) stays undisclosed and gets the interstitial.
     if (modalCta) modalCta.href = '/login?disclosed=1&return_to=' + returnTo()
-    // Same fast path, but for signup: lands on Auth0's native "Sign up" screen
-    // instead of Cloud's cloud.redpanda.com/sign-up onboarding wizard (which
-    // provisions a trial org + resources a docs-only sign-in doesn't need).
-    if (modalSignup) modalSignup.href = '/login?disclosed=1&signup=1&return_to=' + returnTo()
 
     // Signed in: the console link lives in the account dropdown, so hide the
     // standalone toolbar/overflow Cloud Console links (avoid two paths)
@@ -290,13 +289,16 @@
       state_mismatch: 'Your sign-in link expired. Please try again.',
       // Auth0 access_denied: the account isn't a member of a required Redpanda
       // Cloud organization (or declined consent). Retrying the same account won't
-      // help, so say why instead of a generic "try again" loop.
-      access_denied: 'Your account is not in a Redpanda Cloud organization yet. Click the verification link in your email, or ask your organization admin to invite you.',
-      // Signed up but never clicked the verification link Redpanda Cloud emailed.
-      // Kept in sync with LOGIN_ERROR_MESSAGES in docs-site docs-login.mjs: without
-      // an entry here this code fell through to the generic "try again" default,
-      // which is the one thing that cannot work until the address is verified.
-      org_setup_incomplete: 'Click the verification link Redpanda Cloud emailed you, then sign in again.',
+      // help, so say why instead of a generic "try again" loop. Verifying an
+      // emailed address does not create an organization -- only finishing Cloud's
+      // own onboarding does -- so this doesn't point at the inbox.
+      access_denied: 'Your account is not in a Redpanda Cloud organization yet. Ask your organization admin to invite you, or finish setting up your account on Redpanda Cloud.',
+      // Account has no Redpanda Cloud organization yet. Kept in sync with
+      // LOGIN_ERROR_MESSAGES.org_setup_incomplete in docs-site docs-login.mjs:
+      // verifying the emailed address does NOT create an organization (that only
+      // happens inside Cloud's own onboarding wizard), so retrying sign-in fails
+      // identically every time until account setup is actually finished on Cloud.
+      org_setup_incomplete: 'Finish creating your account on Redpanda Cloud, then come back and sign in.',
     }
     var toast = document.createElement('div')
     toast.setAttribute('role', 'alert')

--- a/src/js/26-docs-account.js
+++ b/src/js/26-docs-account.js
@@ -21,6 +21,7 @@
   var signoutLink = container.querySelector('[data-account-signout]')
   var modal = container.querySelector('[data-signin-modal]')
   var modalCta = container.querySelector('[data-signin-modal-continue]')
+  var modalSignup = container.querySelector('[data-signin-modal-signup]')
 
   var CACHE_KEY = 'docs-account-me'
 
@@ -197,6 +198,10 @@
     // and go straight to Auth0. The bare signinLink href (middle-click, or no
     // modal markup) stays undisclosed and gets the interstitial.
     if (modalCta) modalCta.href = '/login?disclosed=1&return_to=' + returnTo()
+    // Same fast path, but for signup: lands on Auth0's native "Sign up" screen
+    // instead of Cloud's cloud.redpanda.com/sign-up onboarding wizard (which
+    // provisions a trial org + resources a docs-only sign-in doesn't need).
+    if (modalSignup) modalSignup.href = '/login?disclosed=1&signup=1&return_to=' + returnTo()
 
     // Signed in: the console link lives in the account dropdown, so hide the
     // standalone toolbar/overflow Cloud Console links (avoid two paths)

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -169,7 +169,13 @@
                 </li>
               </ul>
               <a class="tb-signin-modal-cta" data-signin-modal-continue href="/login">Continue</a>
-              <p class="tb-signin-modal-foot">No account yet? <a href="https://cloud.redpanda.com/sign-up?utm_source=docs&utm_medium=referral&utm_campaign=docs-signup&utm_content=signin-modal" target="_blank" rel="noopener noreferrer">Create a free account</a></p>
+              {{!-- Registers directly against the docs Auth0 client (screen_hint=signup)
+                    instead of Cloud's cloud.redpanda.com/sign-up onboarding wizard, which
+                    provisions a trial org + resources a docs-only sign-in doesn't need.
+                    Same-tab like Continue (docs-account.js sets disclosed=1&signup=1&
+                    return_to=...), not target=_blank: it's our own /login now, not an
+                    external site. --}}
+              <p class="tb-signin-modal-foot">No account yet? <a data-signin-modal-signup href="/login?signup=1">Create a free account</a></p>
               {{!-- Privacy disclosure. The modal CTA links to /login?disclosed=1,
                     which docs-login.mjs uses to SKIP the server interstitial, so
                     for anyone signing in from here this note is the only

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -169,13 +169,17 @@
                 </li>
               </ul>
               <a class="tb-signin-modal-cta" data-signin-modal-continue href="/login">Continue</a>
-              {{!-- Registers directly against the docs Auth0 client (screen_hint=signup)
-                    instead of Cloud's cloud.redpanda.com/sign-up onboarding wizard, which
-                    provisions a trial org + resources a docs-only sign-in doesn't need.
-                    Same-tab like Continue (docs-account.js sets disclosed=1&signup=1&
-                    return_to=...), not target=_blank: it's our own /login now, not an
-                    external site. --}}
-              <p class="tb-signin-modal-foot">No account yet? <a data-signin-modal-signup href="/login?signup=1">Create a free account</a></p>
+              {{!-- Reverted 2026-08-26: registering via Auth0's native screen_hint=signup
+                    (instead of Cloud's cloud.redpanda.com/sign-up wizard) skips org
+                    provisioning entirely -- the docs Auth0 client requires org
+                    membership, so an Auth0-native signup produces a permanently
+                    org-less account (login_error=org_setup_incomplete forever;
+                    verifying the email does not fix it, since org creation only
+                    happens inside Cloud's own onboarding). Team decision was to keep
+                    routing "Create a free account" through Cloud's real wizard and
+                    instead skip the WASTED WELCOME CLUSTER for docs-tagged signups on
+                    the Cloud side (see cloudv2 signUpSource/backoffice-worker work). --}}
+              <p class="tb-signin-modal-foot">No account yet? <a href="https://cloud.redpanda.com/sign-up?utm_source=docs&utm_medium=referral&utm_campaign=docs-signup&utm_content=signin-modal" target="_blank" rel="noopener noreferrer">Create a free account</a></p>
               {{!-- Privacy disclosure. The modal CTA links to /login?disclosed=1,
                     which docs-login.mjs uses to SKIP the server interstitial, so
                     for anyone signing in from here this note is the only


### PR DESCRIPTION
## Summary
The header sign-in modal's "Create a free account" link is hardcoded to `cloud.redpanda.com/sign-up` — Cloud's full onboarding wizard, which provisions a trial org + resources even for a docs-only sign-in.

This mirrors the "Continue" button's existing pattern (`modalCta.href = '/login?disclosed=1&return_to=...'`) for the signup case: point at docs-site's `/login?disclosed=1&signup=1&return_to=...`, which resolves (as of [docs-site#212](https://github.com/redpanda-data/docs-site/pull/212)) to Auth0's native `screen_hint=signup` screen on the docs Auth0 client, instead of Cloud's wizard.

## Depends on
docs-site#212 must land first (or at least the `signup=1` fast path in `docs-login.mjs`) for `/login?signup=1` to resolve correctly — until then this link 404s/falls through to the plain interstitial.

## Why draft
Base is `feature/ask-ai-agent-sdk` (PR #395), not `main` — this only makes sense once that lands. Also: the underlying assumption (Auth0 native signup doesn't trigger Cloud's trial-resource provisioning) is still being verified on the docs-site preview; flagging here in case that turns out false and this needs to be reverted/rethought.

## Test plan
- [ ] docs-site#212 (or its `signup=1` support) is merged into this feature branch's target environment
- [ ] On a preview build, click "Create a free account" from the header sign-in modal
- [ ] Confirm it lands on Auth0's native "Sign up" screen (not cloud.redpanda.com)
- [ ] Confirm `return_to` still round-trips correctly after signup completes