### PR TITLE
fix(tooltips): drop the code border inside glossary tooltips

### DIFF
--- a/src/css/tooltips.css
+++ b/src/css/tooltips.css
@@ -5,6 +5,20 @@
   z-index: 9999;
 }
 
+/* Glossary hover text can contain backtick-monospace, which the glossary macro
+   emits as <code>. Tippy appends the tooltip to <body>, so it escapes the .doc
+   code styling in doc.css but still picks up the site-wide code border in
+   base.css -- a border in the page's code color, drawn on top of the tooltip
+   background, which reads as a box around the term. Monospace is wanted here;
+   the box is not. color: inherit follows --tooltip-font-color so this holds in
+   both themes. */
+.tippy-box[data-theme~='redpanda-term'] code {
+  border: 0;
+  background: none;
+  color: inherit;
+  font-size: 1em;
+}
+
 a.glossary-term {
   border-bottom: 2px dotted var(--link-highlight-color);
   text-decoration: none !important;


### PR DESCRIPTION
## Summary

- `docs-extensions-and-macros#289` teaches the glossary macro to render backtick-monospace in a term's `:hover-text:` as `<code>`. This is the first time a `<code>` element appears inside a tooltip.
- Tippy is configured with `appendTo: () => document.body` (`src/js/12-activate-tooltips.js`), so the tooltip escapes the `.doc code` styling in `doc.css:673` but still picks up the site-wide `code` rule in `base.css:41-47`, which sets `border: 1px solid var(--code-background)`.
- That border is drawn in the page's code color on top of the tooltip background, so each monospaced term renders inside a visible box. Monospace is wanted here; the box is not.
- `color: inherit` follows `--tooltip-font-color`, so the rule holds in both themes.

## Why this ships before the macro change

`docs-site` pulls `ui-bundle.zip` from `releases/latest`. If the macro change ships first, five glossary terms whose hover text contains backticks (`data-plane`, `iceberg-mode`, `node`, `redpanda-catalog`, `segment`) render boxes on the live site until this lands and a release is cut. This rule is inert on its own — until the macro emits `<code>`, the selector matches nothing — so it is safe to merge and release first.

## Test plan

- [x] `npx gulp lint` — `lint:css` and `lint:js` both pass
- [x] Reproduced the defect and verified the fix against the real built `site.css`, using tippy's actual tooltip DOM (`.tippy-box[data-theme='redpanda-term'] > .tippy-content`) and the attribute value taken from an Antora build of the preview site
- [x] Checked light **and** dark themes: light goes from boxed to clean; dark is unchanged (`--code-background` there is `rgba(177, 209, 241, 0.15)`, effectively invisible against the white tooltip)

Light theme, before and after:

| before | after |
|---|---|
| `rpk` and `segment.bytes` each in a bordered box | monospace, no box |

🤖 Generated with [Claude Code](https://claude.com/claude-code)